### PR TITLE
[fix]: stop caller feature flags from discarding local launch defaults

### DIFF
--- a/.changeset/eighty-pugs-repeat.md
+++ b/.changeset/eighty-pugs-repeat.md
@@ -1,0 +1,7 @@
+---
+"@browserbasehq/stagehand-python": patch
+"@browserbasehq/stagehand-go": patch
+"@browserbasehq/stagehand": patch
+---
+
+merge repeated --disable-features and --enable-features into one switch each so caller flags no longer discard the local browser defaults.

--- a/packages/sdk-go/chrome_launcher.go
+++ b/packages/sdk-go/chrome_launcher.go
@@ -252,7 +252,66 @@ func buildChromeArgs(options LocalBrowserLaunchOptions, port int, userDataDir st
 		args = append(args, "--ignore-certificate-errors")
 	}
 	args = append(args, options.Args...)
-	return append(args, "about:blank")
+	return mergeFeatureFlags(append(args, "about:blank"))
+}
+
+var mergeableFeatureFlags = [...]string{"--disable-features", "--enable-features"}
+
+// mergeFeatureFlags emits each of the feature switches once, carrying every
+// value it was given.
+//
+// Chrome parses --disable-features and --enable-features as a single value each.
+// A second occurrence of either switch does not add to the first, it replaces it
+// whole, taking every feature name the first one carried with it.
+//
+// Since the defaults are emitted before options.Args, without this a caller
+// passing any --disable-features of their own would silently drop all ten of the
+// default names, and a caller passing --enable-features would drop the WebMCP
+// switch that the extension surface relies on.
+//
+// Merge instead: keep one switch of each kind, at the position of its first
+// occurrence, carrying the de-duplicated union of every value in list order.
+func mergeFeatureFlags(flags []string) []string {
+	merged := make([]string, 0, len(flags))
+	slotFor := make(map[string]int, len(mergeableFeatureFlags))
+	valuesFor := make(map[string][]string, len(mergeableFeatureFlags))
+	seenValue := make(map[string]map[string]struct{}, len(mergeableFeatureFlags))
+
+	for _, flag := range flags {
+		name := ""
+		for _, candidate := range mergeableFeatureFlags {
+			if strings.HasPrefix(flag, candidate+"=") {
+				name = candidate
+				break
+			}
+		}
+		if name == "" {
+			merged = append(merged, flag)
+			continue
+		}
+		if _, ok := seenValue[name]; !ok {
+			seenValue[name] = map[string]struct{}{}
+		}
+		for _, value := range strings.Split(flag[len(name)+1:], ",") {
+			if value == "" {
+				continue
+			}
+			if _, ok := seenValue[name][value]; ok {
+				continue
+			}
+			seenValue[name][value] = struct{}{}
+			valuesFor[name] = append(valuesFor[name], value)
+		}
+		if _, ok := slotFor[name]; !ok {
+			slotFor[name] = len(merged)
+			merged = append(merged, flag)
+		}
+	}
+
+	for name, slot := range slotFor {
+		merged[slot] = name + "=" + strings.Join(valuesFor[name], ",")
+	}
+	return merged
 }
 
 func selectedDefaultChromeFlags(ignore *IgnoreDefaultArgs) []string {

--- a/packages/sdk-go/chrome_launcher_test.go
+++ b/packages/sdk-go/chrome_launcher_test.go
@@ -116,6 +116,87 @@ func TestBuildChromeArgsPutsCallerArgumentsLast(t *testing.T) {
 	}
 }
 
+// Chrome parses --disable-features and --enable-features as a single value each:
+// a second occurrence replaces the first outright rather than adding to it. Since
+// the defaults are emitted before options.Args, these switches have to be merged
+// or a caller passing one of their own silently drops every default feature name.
+func TestBuildChromeArgsMergesFeatureSwitches(t *testing.T) {
+	featureValues := func(args []string, name string) []string {
+		var found []string
+		for _, arg := range args {
+			if strings.HasPrefix(arg, name+"=") {
+				found = append(found, arg)
+			}
+		}
+		return found
+	}
+
+	t.Run("caller disable-features is added to the defaults", func(t *testing.T) {
+		t.Setenv("CI", "")
+		got := buildChromeArgs(LocalBrowserLaunchOptions{
+			Args: []string{"--disable-features=ExampleFeature"},
+		}, 9_222, "/tmp/profile")
+
+		want := []string{defaultChromeFlags[0] + ",ExampleFeature"}
+		if !slices.Equal(featureValues(got, "--disable-features"), want) {
+			t.Fatalf("buildChromeArgs() --disable-features = %#v, want %#v",
+				featureValues(got, "--disable-features"), want)
+		}
+	})
+
+	t.Run("caller enable-features keeps the WebMCP flag", func(t *testing.T) {
+		t.Setenv("CI", "")
+		got := buildChromeArgs(LocalBrowserLaunchOptions{
+			Args: []string{"--enable-features=ExampleFeature"},
+		}, 9_222, "/tmp/profile")
+
+		want := []string{testWebMCPChromeFlag + ",ExampleFeature"}
+		if !slices.Equal(featureValues(got, "--enable-features"), want) {
+			t.Fatalf("buildChromeArgs() --enable-features = %#v, want %#v",
+				featureValues(got, "--enable-features"), want)
+		}
+	})
+
+	t.Run("repeated switches merge in order without duplicating a value", func(t *testing.T) {
+		t.Setenv("CI", "")
+		got := buildChromeArgs(LocalBrowserLaunchOptions{
+			Args: []string{
+				"--disable-features=Translate,First",
+				"--mute-audio",
+				"--disable-features=Second",
+			},
+		}, 9_222, "/tmp/profile")
+
+		want := defaultChromeFlags[0] + ",First,Second"
+		if got[0] != want {
+			t.Fatalf("buildChromeArgs()[0] = %q, want %q", got[0], want)
+		}
+		if merged := featureValues(got, "--disable-features"); len(merged) != 1 {
+			t.Fatalf("buildChromeArgs() emitted %d --disable-features switches, want 1", len(merged))
+		}
+		if !slices.Contains(got, "--mute-audio") {
+			t.Fatal("buildChromeArgs() dropped an unrelated caller argument")
+		}
+	})
+
+	t.Run("ignoring every default leaves the caller switch alone", func(t *testing.T) {
+		t.Setenv("CI", "")
+		got := buildChromeArgs(LocalBrowserLaunchOptions{
+			IgnoreDefaultArgs: &IgnoreDefaultArgs{All: true},
+			Args:              []string{"--disable-features=ExampleFeature"},
+		}, 9_222, "/tmp/profile")
+
+		want := []string{"--disable-features=ExampleFeature"}
+		if !slices.Equal(featureValues(got, "--disable-features"), want) {
+			t.Fatalf("buildChromeArgs() --disable-features = %#v, want %#v",
+				featureValues(got, "--disable-features"), want)
+		}
+		if enabled := featureValues(got, "--enable-features"); len(enabled) != 0 {
+			t.Fatalf("buildChromeArgs() --enable-features = %#v, want none", enabled)
+		}
+	})
+}
+
 func TestBuildChromeArgsCanIgnoreDefaultArgs(t *testing.T) {
 	t.Run("all", func(t *testing.T) {
 		got := buildChromeArgs(

--- a/packages/sdk-python/src/stagehand/browser.py
+++ b/packages/sdk-python/src/stagehand/browser.py
@@ -693,7 +693,7 @@ def _local_browser_flags(
     )
     window_size_flag = f"--window-size={viewport.width},{viewport.height}"
 
-    return [
+    return _merge_feature_flags([
         *(
             [flag for flag in _DEFAULT_CHROME_FLAGS if flag not in ignored_flags]
             if include_defaults
@@ -726,7 +726,55 @@ def _local_browser_flags(
         *(["--ignore-certificate-errors"] if options.ignore_https_errors is True else []),
         *(options.args or []),
         "about:blank",
-    ]
+    ])
+
+
+_MERGEABLE_FEATURE_FLAGS = ("--disable-features", "--enable-features")
+
+
+def _merge_feature_flags(flags: list[str]) -> list[str]:
+    """Emit each of the feature switches once, carrying every value it was given.
+
+    Chrome parses ``--disable-features`` and ``--enable-features`` as a single
+    value each. A second occurrence of either switch does not add to the first,
+    it replaces it whole, taking every feature name the first one carried with
+    it.
+
+    Since the defaults are emitted before ``options.args``, without this a caller
+    passing any ``--disable-features`` of their own would silently drop all ten
+    of the default names, and a caller passing ``--enable-features`` would drop
+    the WebMCP switch that the extension surface relies on.
+
+    Merge instead: keep one switch of each kind, at the position of its first
+    occurrence, carrying the de-duplicated union of every value in list order.
+    """
+    merged: list[str] = []
+    slot_for: dict[str, int] = {}
+    values_for: dict[str, dict[str, None]] = {}
+
+    for flag in flags:
+        name = next(
+            (
+                candidate
+                for candidate in _MERGEABLE_FEATURE_FLAGS
+                if flag.startswith(f"{candidate}=")
+            ),
+            None,
+        )
+        if name is None:
+            merged.append(flag)
+            continue
+        values = values_for.setdefault(name, {})
+        for value in flag[len(name) + 1 :].split(","):
+            if value:
+                values[value] = None
+        if name not in slot_for:
+            slot_for[name] = len(merged)
+            merged.append(flag)
+
+    for name, slot in slot_for.items():
+        merged[slot] = f"{name}={','.join(values_for.get(name, {}))}"
+    return merged
 
 
 def _find_chrome_path() -> str:

--- a/packages/sdk-python/tests/test_browser.py
+++ b/packages/sdk-python/tests/test_browser.py
@@ -554,6 +554,54 @@ async def test_launch_converts_argument_tuples_to_flag_lists(
     await handle.close()
 
 
+# Chrome parses --disable-features and --enable-features as a single value each:
+# a second occurrence replaces the first outright rather than adding to it. Since
+# the defaults are emitted before options.args, these switches have to be merged
+# or a caller passing one of their own silently drops every default feature name.
+_WEBMCP_CHROME_FLAG = "--enable-features=WebMCPTesting,DevToolsWebMCPSupport"
+
+
+def _feature_values(flags: list[str], name: str) -> list[str]:
+    return [flag for flag in flags if flag.startswith(f"{name}=")]
+
+
+def _flags_for(tmp_path: Path, **overrides: object) -> list[str]:
+    options = LocalBrowserLaunchOptions(**overrides)  # ty: ignore[missing-argument]
+    return _local_browser_flags(options, port=9222, user_data_dir=tmp_path, is_ci=False)
+
+
+def test_feature_flags_merge_caller_values_into_the_defaults(tmp_path: Path) -> None:
+    flags = _flags_for(tmp_path, args=["--disable-features=ExampleFeature"])
+    assert _feature_values(flags, "--disable-features") == [
+        f"{_DEFAULT_CHROME_FLAGS[0]},ExampleFeature"
+    ]
+
+    flags = _flags_for(tmp_path, args=["--enable-features=ExampleFeature"])
+    assert _feature_values(flags, "--enable-features") == [f"{_WEBMCP_CHROME_FLAG},ExampleFeature"]
+
+
+def test_feature_flags_merge_in_order_without_duplicating_a_value(tmp_path: Path) -> None:
+    flags = _flags_for(
+        tmp_path,
+        args=["--disable-features=Translate,First", "--mute-audio", "--disable-features=Second"],
+    )
+
+    assert flags[0] == f"{_DEFAULT_CHROME_FLAGS[0]},First,Second"
+    assert len(_feature_values(flags, "--disable-features")) == 1
+    assert "--mute-audio" in flags
+
+
+def test_feature_flags_leave_the_caller_alone_when_defaults_are_ignored(tmp_path: Path) -> None:
+    flags = _flags_for(
+        tmp_path,
+        ignore_default_args=True,
+        args=["--disable-features=ExampleFeature"],
+    )
+
+    assert _feature_values(flags, "--disable-features") == ["--disable-features=ExampleFeature"]
+    assert _feature_values(flags, "--enable-features") == []
+
+
 async def test_connect_uses_extension_id_or_packaged_extension_and_never_owns_source(
     fake_cdp: type[FakeCDPClient],
 ) -> None:

--- a/packages/sdk-ts/src/browser/localBrowser.ts
+++ b/packages/sdk-ts/src/browser/localBrowser.ts
@@ -186,7 +186,7 @@ export function localBrowserChromeFlags(
   const viewport = options.viewport ?? { width: 1280, height: 800 };
   const windowSizeFlag = `--window-size=${viewport.width},${viewport.height}`;
 
-  return [
+  return mergeFeatureFlags([
     ...(includeDefaults ? selectedChromeFlags(DEFAULT_CHROME_FLAGS, ignoredFlags) : []),
     ...(options.viewport !== undefined || (includeDefaults && !ignoredFlags.has(windowSizeFlag))
       ? [windowSizeFlag]
@@ -206,7 +206,7 @@ export function localBrowserChromeFlags(
     ...(options.ignoreHTTPSErrors === true ? ["--ignore-certificate-errors"] : []),
     ...(options.args ?? []),
     "about:blank",
-  ];
+  ]);
 }
 
 function selectedChromeFlags(
@@ -214,6 +214,52 @@ function selectedChromeFlags(
   ignoredFlags: ReadonlySet<string>,
 ): string[] {
   return flags.filter((flag) => !ignoredFlags.has(flag));
+}
+
+const MERGEABLE_FEATURE_FLAGS = ["--disable-features", "--enable-features"] as const;
+
+/**
+ * Chrome parses `--disable-features` and `--enable-features` as a single value
+ * each. A second occurrence of either switch does not add to the first, it
+ * replaces it whole, taking every feature name the first one carried with it.
+ *
+ * Since the defaults above are emitted before `options.args`, without this a
+ * caller passing any `--disable-features` of their own would silently drop all
+ * ten of the default names, and a caller passing `--enable-features` would drop
+ * the WebMCP switch that the extension surface relies on.
+ *
+ * Merge instead: keep one switch of each kind, at the position of its first
+ * occurrence, carrying the de-duplicated union of every value in list order.
+ */
+function mergeFeatureFlags(flags: string[]): string[] {
+  const merged: string[] = [];
+  const slotFor = new Map<string, number>();
+  const valuesFor = new Map<string, Set<string>>();
+
+  for (const flag of flags) {
+    const name = MERGEABLE_FEATURE_FLAGS.find((candidate) => flag.startsWith(`${candidate}=`));
+    if (name === undefined) {
+      merged.push(flag);
+      continue;
+    }
+    const values = valuesFor.get(name) ?? new Set<string>();
+    for (const value of flag.slice(name.length + 1).split(",")) {
+      if (value !== "") {
+        values.add(value);
+      }
+    }
+    valuesFor.set(name, values);
+    const slot = slotFor.get(name);
+    if (slot === undefined) {
+      slotFor.set(name, merged.length);
+      merged.push(flag);
+    }
+  }
+
+  for (const [name, slot] of slotFor) {
+    merged[slot] = `${name}=${[...(valuesFor.get(name) ?? [])].join(",")}`;
+  }
+  return merged;
 }
 
 function validateLocalBrowserOptions(options: LocalBrowserLaunchOptions): void {

--- a/packages/sdk-ts/tests/browser/localBrowser.test.ts
+++ b/packages/sdk-ts/tests/browser/localBrowser.test.ts
@@ -214,6 +214,67 @@ describe("local browser Chrome flags", () => {
       ),
     ).not.toContain("--window-size=1280,800");
   });
+
+  // Chrome parses --disable-features and --enable-features as a single value
+  // each: a second occurrence replaces the first outright rather than adding to
+  // it. Since the defaults are emitted before options.args, these switches have
+  // to be merged or a caller passing one of their own silently drops every
+  // default feature name.
+  const featureValues = (flags: string[], name: string): string[] =>
+    flags.filter((flag) => flag.startsWith(`${name}=`));
+
+  it("emits a single --disable-features carrying both the defaults and the caller's", () => {
+    const flags = localBrowserChromeFlags(
+      { args: ["--disable-features=ExampleFeature"] },
+      9_222,
+      "/tmp/profile",
+      false,
+    );
+
+    expect(featureValues(flags, "--disable-features")).toStrictEqual([
+      `${DEFAULT_CHROME_FLAGS[0]},ExampleFeature`,
+    ]);
+  });
+
+  it("keeps the WebMCP flag when the caller passes their own --enable-features", () => {
+    const flags = localBrowserChromeFlags(
+      { args: ["--enable-features=ExampleFeature"] },
+      9_222,
+      "/tmp/profile",
+      false,
+    );
+
+    expect(featureValues(flags, "--enable-features")).toStrictEqual([
+      `${WEBMCP_CHROME_FLAG},ExampleFeature`,
+    ]);
+  });
+
+  it("merges repeated feature switches in order without duplicating a value", () => {
+    const flags = localBrowserChromeFlags(
+      { args: ["--disable-features=Translate,First", "--mute-audio", "--disable-features=Second"] },
+      9_222,
+      "/tmp/profile",
+      false,
+    );
+
+    expect(flags[0]).toBe(`${DEFAULT_CHROME_FLAGS[0]},First,Second`);
+    expect(featureValues(flags, "--disable-features")).toHaveLength(1);
+    expect(flags).toContain("--mute-audio");
+  });
+
+  it("leaves the caller's switch alone when the defaults are ignored entirely", () => {
+    const flags = localBrowserChromeFlags(
+      { ignoreDefaultArgs: true, args: ["--disable-features=ExampleFeature"] },
+      9_222,
+      "/tmp/profile",
+      false,
+    );
+
+    expect(featureValues(flags, "--disable-features")).toStrictEqual([
+      "--disable-features=ExampleFeature",
+    ]);
+    expect(featureValues(flags, "--enable-features")).toStrictEqual([]);
+  });
 });
 
 describe("local browser launch lifecycle", () => {


### PR DESCRIPTION
# why

Chrome parses `--disable-features` and `--enable-features` as a **single value
each**. A second occurrence of either switch does not add to the first, it
replaces it whole, taking every feature name the first one carried with it.

The local launcher emits its defaults first and appends `options.args` verbatim
after them, so a caller who passes either switch silently loses the defaults.

**The documented example in `v4/configuration/browser.mdx` is one such caller.**
The prose at line 793 says a set of standard flags "disabling background
networking, component updates, sync, translation, and similar" is prepended.
The example five lines later, in all three language tabs, passes:

```
args: ["--disable-features=site-per-process,IsolateOrigins", "--renderer-process-limit=6"]
```

Feeding exactly that to this repo's own `_local_browser_flags` on `main` puts
two `--disable-features` on the command line and Chrome keeps the second, so
**0 of the 10 default names survive** — including `Translate` and
`CertificateTransparencyComponentUpdater`, the two the prose above names
explicitly.

```
--disable-features switches on the command line: 2
  --disable-features=Translate,OptimizationHints,MediaRouter,DialMediaRouteProvider,CalculateNa...
  --disable-features=site-per-process,IsolateOrigins

default names Chrome will apply: 0 of 10
lost: Translate, OptimizationHints, MediaRouter, DialMediaRouteProvider,
      CalculateNativeWinOcclusion, InterestFeedContentSuggestions,
      CertificateTransparencyComponentUpdater, AutofillServerCommunication,
      PrivacySandboxSettings4, RenderDocument
```

The `--enable-features` side has the same shape, and there the casualty is
`WebMCPTesting,DevToolsWebMCPSupport` — the flag added in #2229 that the
documented WebMCP surface depends on.

Same code shape in all three SDKs:

| SDK | defaults | user args appended |
|---|---|---|
| TypeScript | `DEFAULT_CHROME_FLAGS`, `localBrowser.ts:14` | `localBrowser.ts:207` |
| Python | `_DEFAULT_CHROME_FLAGS`, `browser.py:36` | `browser.py:727` |
| Go | `defaultChromeFlags`, `chrome_launcher.go:28` | `chrome_launcher.go:254` |

Nothing downstream repairs this. Chrome is raw-spawned, so there is no puppeteer
layer in the way — puppeteer's `ChromeLauncher.defaultArgs` does merge these two
switches out of user args, which is why the defect is invisible in libraries
that launch through it.

`ignoreDefaultArgs` is not a workaround. It filters by exact whole-string
equality against a 247-character default, so it cannot express "keep nine of the
ten"; the only thing a caller can do with it is drop the whole flag, at which
point all ten names are gone anyway.

# what changed

One helper per SDK, applied to the fully assembled argument list: keep one
switch of each kind, at the position of its **first** occurrence, carrying the
de-duplicated union of every value in list order.

- `packages/sdk-ts/src/browser/localBrowser.ts` — `mergeFeatureFlags`
- `packages/sdk-python/src/stagehand/browser.py` — `_merge_feature_flags`
- `packages/sdk-go/chrome_launcher.go` — `mergeFeatureFlags`

The same documented example now yields one switch carrying 12 names — the ten
defaults plus the caller's `site-per-process` and `IsolateOrigins`. Both intents
are honoured instead of one silently winning.

Position-of-first-occurrence and order-preserving dedupe are deliberate: with no
user args the output is byte-identical to today, so the existing
`EXPECTED_DEFAULT_CHROME_FLAGS` assertions still hold as written, as does the
`tests/fixtures/local-browser-default-flags.json` fixture being added in #2864.
This is a behaviour change only on the path that is currently broken.

Regression tests in each SDK cover: caller values merged into the defaults, the
WebMCP flag surviving a caller `--enable-features`, repeated switches merged in
order without duplicating a value, and the caller's switch left untouched when
the defaults are ignored entirely.

If a reference is useful, `browser-use`'s `get_args()` solves this the same way,
with a comment saying that merging is what stops one option from silently
breaking another.

# test plan

**The defect was measured, not read off Chromium source.**

*The launcher emits two switches.* Ran this repo's own `_local_browser_flags`
with the real `_DEFAULT_CHROME_FLAGS` and the documented example's `args` — the
output quoted above. No reimplementation, no paraphrase.

*The second one wins.* Unbranded Chromium 151.0.7922.34 on `about:blank`, five
arms, each launched twice, run once headless and once headful — identical
results throughout. Indicator is `DocumentPictureInPictureAPI`, which gates the
`documentPictureInPicture` window property. The value used is this repo's
unedited 247-character default, not a stand-in string:

| arm | command line | `documentPictureInPicture` |
|---|---|---|
| baseline | no `--disable-features` | present |
| stagehand | its default, alone | present |
| discarded | its default, then the caller's | **absent — caller's switch applied** |
| order control | the caller's, then its default | **present — caller's switch discarded** |
| merged | one switch carrying both values | absent — the merge is the fix |

The order-control row is the measurement: this repo's own string is last, the
caller's feature name is on the command line too, and its effect is gone. The
third row is the control that keeps "the second switch discarded the first"
distinct from "one name re-enabled the other".

**One thing I did not observe directly, so I am not claiming it.** Disabling the
ten default names produces no change in the JS surface of this build, so I could
not watch them being lost in the browser. That they are lost follows from the
rule above plus the emission order, both measured — but that step is inference,
and the limit is in my detector rather than in the argument.

**Gates.** `just` is not installed on my machine, so each was run as its
underlying tool, and every result is a **delta against pristine `main`**, because
this host fails some of these tests on stock (Windows path separators;
`Chrome installation not found; set CHROME_PATH`).

| gate | result |
|---|---|
| `oxfmt --check` (TS) | pass on both changed files |
| `oxlint` (TS) | pass |
| `tsc --strict` on `localBrowser.ts` | pass |
| `vitest run packages/sdk-ts/tests` | 4 failed / 237 passed — `main` gives 4 failed / 233 passed. Same 4 failures, +4 passes |
| `ruff format --check` / `ruff check` | pass |
| `pytest` | 2 failed / 48 passed — `main` gives 2 failed / 45 passed. Same 2 failures, +3 passes |
| `gofmt -l` | clean |
| `go vet`, `go test` | **not run** — I have Go 1.25.4 and `go.mod` requires 1.26.0 |

So the Go change is compile-unverified on my side, and I would rather say that
than imply CI-equivalent coverage. Its test is written and mirrors the other two.

**On #2864.** That PR touches the same six files, and I expect this to conflict
with it in `browser.py` and `chrome_launcher.go`. It does not address this bug —
neither "features" nor any merging appears in its diff — so the two are
independent. Happy to rebase onto it once it lands, or to retarget this at
`local-launcher-parity` if you would rather take it as part of that stack.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges repeated `--disable-features` and `--enable-features` flags in the local Chrome launcher for the TypeScript, Python, and Go SDKs so caller args no longer silently discard the default feature flags.

- Chrome parses each switch as a single value, so a second occurrence replaces the first entirely instead of adding to it.
- The launcher emitted defaults first and appended `options.args` verbatim, which dropped all ten default names when a caller passed either switch.
- Each switch is now emitted once at its first position, carrying the de-duplicated union of values in list order.
- Output is byte-identical when no caller switch is present, so existing default-flag assertions still hold.
- Regression tests cover merged caller values, WebMCP flag survival, repeated-switch ordering, and the ignored-defaults path.

<sup>Written for commit d0712e7807942a3803fbf600b3eebd069683e1ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

