### PR TITLE
fix(ci): restore GitHub releases for v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHANGESETS_ACTION_PRESERVE_CHANGELOGS: "true"
 
+      # Package changelogs are intentionally consolidated into the root changelog and
+      # omitted from git. Changesets Action silently skips GitHub Release creation when
+      # a package changelog is absent, so reconcile tagged TypeScript releases explicitly.
+      - name: Reconcile GitHub Releases
+        run: pnpm exec tsx scripts/release/reconcile-github-releases.ts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-typescript-alpha:
     name: Publish TypeScript SDK alpha
     needs: release-typescript

--- a/scripts/release/reconcile-github-releases.test.ts
+++ b/scripts/release/reconcile-github-releases.test.ts
@@ -1,12 +1,23 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  ChangelogParseError,
   parseTypeScriptReleases,
   reconcileGitHubReleases,
   type TypeScriptRelease,
 } from "./reconcile-github-releases.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await rm(directory, { recursive: true, force: true });
+    }),
+  );
+});
 
 const changelog = `# Stagehand
 
@@ -37,6 +48,7 @@ const changelog = `# Stagehand
 
 async function repositoryFixture(contents = changelog): Promise<string> {
   const repositoryRoot = await mkdtemp(path.join(os.tmpdir(), "stagehand-releases-"));
+  temporaryDirectories.push(repositoryRoot);
   await writeFile(path.join(repositoryRoot, "CHANGELOG.md"), contents);
   return repositoryRoot;
 }
@@ -70,15 +82,17 @@ describe("parseTypeScriptReleases", () => {
         prerelease: true,
       },
     ]);
-    expect(() => parseTypeScriptReleases("## TypeScript SDK next\n\n- Invalid.\n")).toThrow(
-      "Invalid TypeScript SDK changelog version: next",
-    );
+    const malformedChangelog = () =>
+      parseTypeScriptReleases("## TypeScript SDK next\n\n- Invalid.\n");
+    expect(malformedChangelog).toThrow(ChangelogParseError);
+    expect(malformedChangelog).toThrow("Invalid TypeScript SDK changelog version");
+    expect(malformedChangelog).not.toThrow("next");
   });
 
   it("rejects empty release notes", () => {
     expect(() =>
       parseTypeScriptReleases("## TypeScript SDK 4.1.0\n\n## Python SDK 4.1.0\n"),
-    ).toThrow("TypeScript SDK 4.1.0 has empty release notes");
+    ).toThrow("TypeScript SDK changelog entry has empty release notes");
   });
 });
 

--- a/scripts/release/reconcile-github-releases.test.ts
+++ b/scripts/release/reconcile-github-releases.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  parseTypeScriptReleases,
+  reconcileGitHubReleases,
+  type TypeScriptRelease,
+} from "./reconcile-github-releases.ts";
+
+const changelog = `# Stagehand
+
+## TypeScript SDK 4.0.2
+
+### Patch Changes
+
+- Fix reattachment.
+
+## Python SDK 4.0.2
+
+### Patch Changes
+
+- Fix reattachment.
+
+## TypeScript SDK 4.0.1
+
+### Patch Changes
+
+- Track the SDK version.
+
+## 3.7.1
+
+### Patch Changes
+
+- Maintain v3.
+`;
+
+async function repositoryFixture(contents = changelog): Promise<string> {
+  const repositoryRoot = await mkdtemp(path.join(os.tmpdir(), "stagehand-releases-"));
+  await writeFile(path.join(repositoryRoot, "CHANGELOG.md"), contents);
+  return repositoryRoot;
+}
+
+describe("parseTypeScriptReleases", () => {
+  it("extracts TypeScript notes oldest-first without including adjacent SDK sections", () => {
+    expect(parseTypeScriptReleases(changelog)).toEqual([
+      {
+        version: "4.0.1",
+        tag: "@browserbasehq/stagehand@4.0.1",
+        notes: "### Patch Changes\n\n- Track the SDK version.",
+        prerelease: false,
+      },
+      {
+        version: "4.0.2",
+        tag: "@browserbasehq/stagehand@4.0.2",
+        notes: "### Patch Changes\n\n- Fix reattachment.",
+        prerelease: false,
+      },
+    ]);
+  });
+
+  it("marks prereleases and rejects malformed versions", () => {
+    expect(
+      parseTypeScriptReleases("## TypeScript SDK 4.1.0-beta.1\n\n- Preview release.\n"),
+    ).toEqual([
+      {
+        version: "4.1.0-beta.1",
+        tag: "@browserbasehq/stagehand@4.1.0-beta.1",
+        notes: "- Preview release.",
+        prerelease: true,
+      },
+    ]);
+    expect(() => parseTypeScriptReleases("## TypeScript SDK next\n\n- Invalid.\n")).toThrow(
+      "Invalid TypeScript SDK changelog version: next",
+    );
+  });
+
+  it("rejects empty release notes", () => {
+    expect(() =>
+      parseTypeScriptReleases("## TypeScript SDK 4.1.0\n\n## Python SDK 4.1.0\n"),
+    ).toThrow("TypeScript SDK 4.1.0 has empty release notes");
+  });
+});
+
+describe("reconcileGitHubReleases", () => {
+  it("creates only tagged releases that do not already exist", async () => {
+    const repositoryRoot = await repositoryFixture();
+    const tagExists = vi.fn(async (tag: string) => !tag.endsWith("4.0.1"));
+    const releaseExists = vi.fn(async () => false);
+    const created: TypeScriptRelease[] = [];
+
+    await expect(
+      reconcileGitHubReleases({
+        repositoryRoot,
+        tagExists,
+        releaseExists,
+        createRelease: async (release) => {
+          created.push(release);
+        },
+      }),
+    ).resolves.toEqual(["@browserbasehq/stagehand@4.0.2"]);
+
+    expect(created).toEqual([parseTypeScriptReleases(changelog)[1]]);
+    expect(releaseExists).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not recreate an existing GitHub Release", async () => {
+    const repositoryRoot = await repositoryFixture(
+      "## TypeScript SDK 4.0.2\n\n- Fix reattachment.\n",
+    );
+    const createRelease = vi.fn();
+
+    await expect(
+      reconcileGitHubReleases({
+        repositoryRoot,
+        tagExists: async () => true,
+        releaseExists: async () => true,
+        createRelease,
+      }),
+    ).resolves.toEqual([]);
+    expect(createRelease).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/release/reconcile-github-releases.ts
+++ b/scripts/release/reconcile-github-releases.ts
@@ -1,0 +1,149 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const packageName = "@browserbasehq/stagehand";
+const sectionPrefix = "TypeScript SDK ";
+const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/u;
+
+export type TypeScriptRelease = {
+  version: string;
+  tag: string;
+  notes: string;
+  prerelease: boolean;
+};
+
+export type ReconcileGitHubReleasesOptions = {
+  repositoryRoot?: string;
+  repository?: string;
+  tagExists?: (tag: string) => Promise<boolean>;
+  releaseExists?: (tag: string) => Promise<boolean>;
+  createRelease?: (release: TypeScriptRelease) => Promise<void>;
+};
+
+type ExecFileError = Error & {
+  code?: number | string;
+  stderr?: string;
+};
+
+export function parseTypeScriptReleases(changelog: string): TypeScriptRelease[] {
+  const headings = [...changelog.matchAll(/^##\s+(.+)$/gmu)];
+  const releases: TypeScriptRelease[] = [];
+
+  for (const [index, match] of headings.entries()) {
+    const heading = match[1]?.trim();
+    if (heading === undefined || !heading.startsWith(sectionPrefix)) continue;
+
+    const version = heading.slice(sectionPrefix.length);
+    if (!semverPattern.test(version)) {
+      throw new Error(`Invalid TypeScript SDK changelog version: ${version}`);
+    }
+
+    const start = (match.index ?? 0) + match[0].length;
+    const end = headings[index + 1]?.index ?? changelog.length;
+    const notes = changelog.slice(start, end).trim();
+    if (notes.length === 0) {
+      throw new Error(`TypeScript SDK ${version} has empty release notes`);
+    }
+
+    releases.push({
+      version,
+      tag: `${packageName}@${version}`,
+      notes,
+      prerelease: version.includes("-"),
+    });
+  }
+
+  // The root changelog is newest-first. Create missing historical releases
+  // oldest-first so GitHub's automatic "Latest" selection ends on the newest SDK.
+  return releases.reverse();
+}
+
+async function localTagExists(repositoryRoot: string, tag: string): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["show-ref", "--verify", "--quiet", `refs/tags/${tag}`], {
+      cwd: repositoryRoot,
+    });
+    return true;
+  } catch (error) {
+    if ((error as ExecFileError).code === 1) return false;
+    throw error;
+  }
+}
+
+async function githubReleaseExists(repository: string, tag: string): Promise<boolean> {
+  try {
+    await execFileAsync("gh", ["release", "view", tag, "--repo", repository, "--json", "tagName"]);
+    return true;
+  } catch (error) {
+    const execError = error as ExecFileError;
+    if (execError.code === 1 && execError.stderr?.trim() === "release not found") return false;
+    throw error;
+  }
+}
+
+async function createGitHubRelease(
+  repositoryRoot: string,
+  repository: string,
+  release: TypeScriptRelease,
+): Promise<void> {
+  const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "stagehand-release-"));
+  const notesPath = path.join(temporaryDirectory, "notes.md");
+
+  try {
+    await writeFile(notesPath, `${release.notes}\n`, { mode: 0o600 });
+    const args = [
+      "release",
+      "create",
+      release.tag,
+      "--repo",
+      repository,
+      "--title",
+      release.tag,
+      "--notes-file",
+      notesPath,
+      "--verify-tag",
+    ];
+    if (release.prerelease) args.push("--prerelease");
+    await execFileAsync("gh", args, { cwd: repositoryRoot });
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+export async function reconcileGitHubReleases({
+  repositoryRoot = path.resolve(import.meta.dirname, "../.."),
+  repository = process.env.GITHUB_REPOSITORY ?? "browserbase/stagehand",
+  tagExists = async (tag) => await localTagExists(repositoryRoot, tag),
+  releaseExists = async (tag) => await githubReleaseExists(repository, tag),
+  createRelease = async (release) => await createGitHubRelease(repositoryRoot, repository, release),
+}: ReconcileGitHubReleasesOptions = {}): Promise<string[]> {
+  const changelog = await readFile(path.join(repositoryRoot, "CHANGELOG.md"), "utf8");
+  const created: string[] = [];
+
+  for (const release of parseTypeScriptReleases(changelog)) {
+    if (!(await tagExists(release.tag)) || (await releaseExists(release.tag))) continue;
+
+    await createRelease(release);
+    created.push(release.tag);
+  }
+
+  return created;
+}
+
+const invokedPath = process.argv[1];
+if (
+  invokedPath !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(invokedPath)).href
+) {
+  const created = await reconcileGitHubReleases();
+  if (created.length === 0) {
+    process.stdout.write("GitHub Releases are already in sync.\n");
+  } else {
+    process.stdout.write(`Created GitHub Releases: ${created.join(", ")}\n`);
+  }
+}

--- a/scripts/release/reconcile-github-releases.ts
+++ b/scripts/release/reconcile-github-releases.ts
@@ -30,6 +30,17 @@ type ExecFileError = Error & {
   stderr?: string;
 };
 
+export class ChangelogParseError extends Error {
+  constructor(reason: "invalid-version" | "empty-notes") {
+    super(
+      reason === "invalid-version"
+        ? "Invalid TypeScript SDK changelog version"
+        : "TypeScript SDK changelog entry has empty release notes",
+    );
+    this.name = "ChangelogParseError";
+  }
+}
+
 export function parseTypeScriptReleases(changelog: string): TypeScriptRelease[] {
   const headings = [...changelog.matchAll(/^##\s+(.+)$/gmu)];
   const releases: TypeScriptRelease[] = [];
@@ -40,14 +51,14 @@ export function parseTypeScriptReleases(changelog: string): TypeScriptRelease[] 
 
     const version = heading.slice(sectionPrefix.length);
     if (!semverPattern.test(version)) {
-      throw new Error(`Invalid TypeScript SDK changelog version: ${version}`);
+      throw new ChangelogParseError("invalid-version");
     }
 
     const start = (match.index ?? 0) + match[0].length;
     const end = headings[index + 1]?.index ?? changelog.length;
     const notes = changelog.slice(start, end).trim();
     if (notes.length === 0) {
-      throw new Error(`TypeScript SDK ${version} has empty release notes`);
+      throw new ChangelogParseError("empty-notes");
     }
 
     releases.push({
@@ -63,14 +74,16 @@ export function parseTypeScriptReleases(changelog: string): TypeScriptRelease[] 
   return releases.reverse();
 }
 
-async function localTagExists(repositoryRoot: string, tag: string): Promise<boolean> {
+async function remoteTagExists(repositoryRoot: string, tag: string): Promise<boolean> {
   try {
-    await execFileAsync("git", ["show-ref", "--verify", "--quiet", `refs/tags/${tag}`], {
-      cwd: repositoryRoot,
-    });
+    await execFileAsync(
+      "git",
+      ["ls-remote", "--exit-code", "--tags", "origin", `refs/tags/${tag}`],
+      { cwd: repositoryRoot },
+    );
     return true;
   } catch (error) {
-    if ((error as ExecFileError).code === 1) return false;
+    if ((error as ExecFileError).code === 2) return false;
     throw error;
   }
 }
@@ -118,7 +131,7 @@ async function createGitHubRelease(
 export async function reconcileGitHubReleases({
   repositoryRoot = path.resolve(import.meta.dirname, "../.."),
   repository = process.env.GITHUB_REPOSITORY ?? "browserbase/stagehand",
-  tagExists = async (tag) => await localTagExists(repositoryRoot, tag),
+  tagExists = async (tag) => await remoteTagExists(repositoryRoot, tag),
   releaseExists = async (tag) => await githubReleaseExists(repository, tag),
   createRelease = async (release) => await createGitHubRelease(repositoryRoot, repository, release),
 }: ReconcileGitHubReleasesOptions = {}): Promise<string[]> {


### PR DESCRIPTION
## Summary

- reconcile tagged TypeScript SDK versions against GitHub Releases after Changesets runs
- source release notes from the consolidated root changelog
- backfill missing v4.0.0, v4.0.1, and v4.0.2 releases oldest-first
- keep reconciliation idempotent and require an existing git tag

## Root cause

The v4 release flow consolidates generated package changelogs into the root changelog and omits the package changelogs from git. Changesets Action silently skips GitHub Release creation when the published package changelog is absent, even though npm publishing and tag creation succeed.

## Test plan

- pnpm test:unit
- pnpm build
- pnpm check
- verified the root changelog resolves the three tagged-but-missing v4 TypeScript releases

No changeset: release automation only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores GitHub Releases for v4 TypeScript SDK versions that were published and tagged but never got a release because Changesets Action skips release creation when package changelogs are absent.

- Adds a reconciliation script that parses TypeScript SDK sections from the root changelog and creates missing GitHub Releases for tagged versions.
- Runs in the release workflow after Changesets and is idempotent: it skips tags without an existing git tag and releases that already exist.
- Fails on malformed changelog entries and marks prerelease versions as prereleases.
- Backfills missing v4.0.0, v4.0.1, and v4.0.2 releases oldest-first so GitHub's latest release lands on the newest version.

<sup>Written for commit 53ce80a37b10d3bd8bb0e6ed26b7420b26ae9c0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

