### PR TITLE
docs(models): add openaiEndpointFormat chat example for custom endpoints (#2844)

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -813,6 +813,22 @@ const stagehand = new Stagehand({
 });
 ```
 
+#### Chat Completions-only endpoints
+
+By default, Stagehand uses OpenAI's Responses API format. If your OpenAI-compatible host only supports standard Chat Completions (such as Databricks, vLLM, or other OpenAI-compatible proxies), specify `openaiEndpointFormat: "chat"`:
+
+```typescript
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: {
+    modelName: "openai/deepseek-v4-flash",
+    apiKey: process.env.CUSTOM_API_KEY,
+    baseURL: "https://api.pzero.studio/v1",
+    openaiEndpointFormat: "chat"
+  }
+});
+```
+
 </Tab>
 
 <Tab title="Anthropic">


### PR DESCRIPTION
## Summary
- Resolves #2844
- Documents the `openaiEndpointFormat: "chat"` configuration option introduced in #2347
- Adds an explicit code snippet demonstrating how to configure custom endpoints for OpenAI-compatible providers that only support the standard Chat Completions API format rather than the Responses API format.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the `openaiEndpointFormat: "chat"` option for OpenAI-compatible providers that only support Chat Completions, with a code example. Resolves #2844.

<sup>Written for commit b2d763c93f5c17773afbc069745afb9ba2aeffd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

