### PR TITLE
Expand `Page.on` to support custom event return classes

### DIFF
--- a/packages/extension/runtime.ts
+++ b/packages/extension/runtime.ts
@@ -56,7 +56,7 @@ import type {
   PageClickParams,
   PageCloseResult,
   PageCDPEvent,
-  PageCDPEventNotification,
+  PageEventNotification,
   PageEventName,
   PageAddInitScriptParams,
   PageDragAndDropParams,
@@ -265,7 +265,7 @@ export type StagehandRuntimeAdapters = {
   browserSessionFactory?: StagehandBrowserSessionFactory;
   emitLog?: StagehandLogEmitter;
   clientLLMGenerate?: (params: LLMGenerateParams) => Promise<LLMGenerateResult>;
-  emitPageCDPEvent?: (notification: PageCDPEventNotification) => void;
+  emitPageEvent?: (notification: PageEventNotification) => void;
 };
 
 type ResolvedStagehandRuntimeAdapters = Required<StagehandRuntimeAdapters>;
@@ -288,7 +288,7 @@ export function createStagehandRuntime(
       browserSessionFactory: adapters.browserSessionFactory ?? defaultBrowserSessionFactory,
       emitLog: adapters.emitLog ?? discardLog,
       clientLLMGenerate: adapters.clientLLMGenerate ?? unavailableClientLLM,
-      emitPageCDPEvent: adapters.emitPageCDPEvent ?? discardPageCDPEvent,
+      emitPageEvent: adapters.emitPageEvent ?? discardPageCDPEvent,
     },
     tracing,
   );
@@ -748,7 +748,7 @@ export class StagehandRuntime {
       throw new DuplicatePageEventSubscriptionError();
     }
     const dispose = this.resolvePage(params.pageId).subscribeCDPEvent(params.event, (event) => {
-      this.adapters.emitPageCDPEvent({ subscriptionId: params.subscriptionId, event });
+      this.adapters.emitPageEvent({ subscriptionId: params.subscriptionId, event });
     });
     this.pageEventSubscriptions.set(params.subscriptionId, { pageId: params.pageId, dispose });
     return { ok: true };

--- a/packages/extension/service-worker.ts
+++ b/packages/extension/service-worker.ts
@@ -57,13 +57,13 @@ export function startStagehandServiceWorker(
           console.error("[stagehand] Failed to emit log notification", error);
         });
       },
-      emitPageCDPEvent: (notification) => {
+      emitPageEvent: (notification) => {
         void rpcClient
-          ?.notify(StagehandNotifications.pageCDPEvent, notification)
+          ?.notify(StagehandNotifications.event, notification)
           .catch((error: unknown) => {
             // This notification cannot safely report its own delivery failure over JSON-RPC.
             // oxlint-disable-next-line no-console
-            console.error("[stagehand] Failed to emit page CDP event notification", error);
+            console.error("[stagehand] Failed to emit page event notification", error);
           });
       },
       clientLLMGenerate: async (params) => {

--- a/packages/extension/tests/stagehand-clients.test.ts
+++ b/packages/extension/tests/stagehand-clients.test.ts
@@ -43,7 +43,7 @@ import type {
   PageClickParams,
   PageEventName,
   PageCDPEvent,
-  PageCDPEventNotification,
+  PageEventNotification,
   PageDragAndDropParams,
   PageEvaluateParams,
   PageKeyPressParams,
@@ -733,10 +733,10 @@ describe("Stagehand worker clients", () => {
   it("canonicalizes the console alias and stops page notifications after page.off", async () => {
     const page = new FakeUnderstudyRuntimePage("page-a", "about:blank");
     const session = new FakeBrowserSession([page]);
-    const notifications: PageCDPEventNotification[] = [];
+    const notifications: PageEventNotification[] = [];
     const runtime = createStagehandRuntime({
       browserSessionFactory: async () => session,
-      emitPageCDPEvent: (notification) => notifications.push(notification),
+      emitPageEvent: (notification) => notifications.push(notification),
     });
     await runtime.replaceBrowserConnection({
       cdpUrl: "ws://127.0.0.1:9222/devtools/browser/session",

--- a/packages/protocol/schema-registry.ts
+++ b/packages/protocol/schema-registry.ts
@@ -62,7 +62,7 @@ import {
   LLMGenerateResultSchema,
   ObserveResultSchema,
   PageAddInitScriptParamsSchema,
-  PageCDPEventNotificationSchema,
+  PageEventNotificationSchema,
   PageClickParamsSchema,
   PageCloseResultSchema,
   PageDragAndDropParamsSchema,
@@ -535,9 +535,9 @@ export const StagehandRpcRequestSchema = z
 
 export const StagehandNotifications = {
   log: { name: "stagehand.log", params: StagehandLogSchema, paramsWire: undefined },
-  pageCDPEvent: {
-    name: "page.cdp_event",
-    params: PageCDPEventNotificationSchema,
+  event: {
+    name: "page.event",
+    params: PageEventNotificationSchema,
     paramsWire: { opaqueKeys: ["params"] },
   },
 } as const satisfies Record<string, RPCNotification>;

--- a/packages/protocol/schemas.ts
+++ b/packages/protocol/schemas.ts
@@ -1441,7 +1441,9 @@ export const ResponseFinishedResultSchema = z
   })
   .meta({ id: "ResponseFinishedResult" });
 
-export const PageEventNameSchema = z.enum(["console"]).meta({ id: "PageEventName" });
+export const PageEventNameSchema = z
+  .enum(["console", "requestfinished"])
+  .meta({ id: "PageEventName" });
 
 export const PageCDPEventParamsSchema = z
   .record(z.string(), z.json())
@@ -1457,12 +1459,18 @@ export const PageCDPEventSchema = z
   })
   .meta({ id: "PageCDPEvent" });
 
-export const PageCDPEventNotificationSchema = z
+export const PageEventSchemas = {
+  console: PageCDPEventSchema,
+  requestfinished: NavigationResponseDescriptorSchema,
+} satisfies Record<z.infer<typeof PageEventNameSchema>, z.ZodType>;
+
+const PageEventPayloadSchema = z.union(Object.values(PageEventSchemas));
+export const PageEventNotificationSchema = z
   .strictObject({
     subscriptionId: z.string().min(1),
-    event: PageCDPEventSchema,
+    event: PageEventPayloadSchema,
   })
-  .meta({ id: "PageCDPEventNotification" });
+  .meta({ id: "PageEventNotification" });
 
 export const WebMCPAnnotationSchema = z
   .strictObject({

--- a/packages/protocol/stagehand.v4.json
+++ b/packages/protocol/stagehand.v4.json
@@ -1088,18 +1088,18 @@
           "required": ["params"],
           "additionalProperties": false
         },
-        "page.cdp_event": {
+        "page.event": {
           "type": "object",
           "properties": {
             "params": {
-              "$ref": "#/$defs/PageCDPEventNotification"
+              "$ref": "#/$defs/PageEventNotification"
             }
           },
           "required": ["params"],
           "additionalProperties": false
         }
       },
-      "required": ["stagehand.log", "page.cdp_event"],
+      "required": ["stagehand.log", "page.event"],
       "additionalProperties": false
     },
     "legacy_client_models": {
@@ -3634,7 +3634,7 @@
     },
     "PageEventName": {
       "type": "string",
-      "enum": ["console"]
+      "enum": ["console", "requestfinished"]
     },
     "PageOffParams": {
       "type": "object",
@@ -4859,7 +4859,7 @@
         }
       ]
     },
-    "PageCDPEventNotification": {
+    "PageEventNotification": {
       "type": "object",
       "properties": {
         "subscription_id": {
@@ -4867,7 +4867,14 @@
           "minLength": 1
         },
         "event": {
-          "$ref": "#/$defs/PageCDPEvent"
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PageCDPEvent"
+            },
+            {
+              "$ref": "#/$defs/NavigationResponseDescriptor"
+            }
+          ]
         }
       },
       "required": ["subscription_id", "event"],
@@ -7265,10 +7272,10 @@
             },
             "method": {
               "type": "string",
-              "const": "page.cdp_event"
+              "const": "page.event"
             },
             "params": {
-              "$ref": "#/$defs/PageCDPEventNotification"
+              "$ref": "#/$defs/PageEventNotification"
             }
           },
           "required": ["jsonrpc", "method", "params"],

--- a/packages/protocol/tests/protocol/page-events.test.ts
+++ b/packages/protocol/tests/protocol/page-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { encodeWireValue, wireSchema } from "../../json-rpc/wire-casing.js";
 import {
-  PageCDPEventNotificationSchema,
+  PageEventNotificationSchema,
   PageCDPEventSchema,
   PageEventNameSchema,
 } from "../../schemas.js";
@@ -44,10 +44,10 @@ describe("console page events", () => {
   it("registers subscription methods and the console event notification", () => {
     expect(StagehandMethods.pageOn.name).toBe("page.on");
     expect(StagehandMethods.pageOff.name).toBe("page.off");
-    expect(StagehandNotifications.pageCDPEvent.name).toBe("page.cdp_event");
+    expect(StagehandNotifications.event.name).toBe("page.event");
 
     expect(
-      PageCDPEventNotificationSchema.parse({
+      PageEventNotificationSchema.parse({
         subscriptionId: "subscription-1",
         event: {
           pageId: "page-1",
@@ -71,7 +71,7 @@ describe("console page events", () => {
         targetId: "target-1",
       },
     };
-    const wireValue = encodeWireValue(apiValue, StagehandNotifications.pageCDPEvent.paramsWire);
+    const wireValue = encodeWireValue(apiValue, StagehandNotifications.event.paramsWire);
 
     expect(wireValue).toStrictEqual({
       subscription_id: "subscription-1",
@@ -85,8 +85,8 @@ describe("console page events", () => {
     });
     expect(
       wireSchema(
-        StagehandNotifications.pageCDPEvent.params,
-        StagehandNotifications.pageCDPEvent.paramsWire,
+        StagehandNotifications.event.params,
+        StagehandNotifications.event.paramsWire,
       ).parse(wireValue),
     ).toStrictEqual(apiValue);
   });

--- a/packages/protocol/types.ts
+++ b/packages/protocol/types.ts
@@ -145,7 +145,7 @@ import type {
   ObserveOptionsSchema,
   ObserveResultSchema,
   PageAddInitScriptParamsSchema,
-  PageCDPEventNotificationSchema,
+  PageEventNotificationSchema,
   PageCDPEventParamsSchema,
   PageCDPEventSchema,
   PageClickParamsSchema,
@@ -184,6 +184,7 @@ import type {
   PageWaitForLoadStateParamsSchema,
   PageWaitForSelectorParamsSchema,
   PageWaitForSelectorResultSchema,
+  PageEventSchemas,
   PageWaitForTimeoutParamsSchema,
   PageWebMCPCancelInvocationParamsSchema,
   PageWebMCPInvocationResultParamsSchema,
@@ -300,9 +301,10 @@ export type EmptyParams = z.infer<typeof EmptyParamsSchema>;
 export type ContextVoidResult = z.infer<typeof ContextVoidResultSchema>;
 export type PageRef = z.infer<typeof PageRefSchema>;
 export type PageEventName = z.infer<typeof PageEventNameSchema>;
+export type PageEvent<E extends PageEventName> = z.infer<(typeof PageEventSchemas)[E]>;
+export type PageEventNotification = z.infer<typeof PageEventNotificationSchema>;
 export type PageCDPEventParams = z.infer<typeof PageCDPEventParamsSchema>;
 export type PageCDPEvent = z.infer<typeof PageCDPEventSchema>;
-export type PageCDPEventNotification = z.infer<typeof PageCDPEventNotificationSchema>;
 export type PageNavigationOptions = z.infer<typeof PageNavigationOptionsSchema>;
 export type NavigationHeader = z.infer<typeof NavigationHeaderSchema>;
 export type NavigationSecurityDetails = z.infer<typeof NavigationSecurityDetailsSchema>;

--- a/packages/sdk-python/src/stagehand/_generated/input_types.py
+++ b/packages/sdk-python/src/stagehand/_generated/input_types.py
@@ -682,11 +682,6 @@ class PageCDPEvent(TypedDict):
     target_id: str
 
 
-class PageCDPEventNotification(TypedDict):
-    subscription_id: str
-    event: PageCDPEvent
-
-
 class PageClickOptions(TypedDict):
     button: NotRequired[MouseButton]
     click_count: NotRequired[int]
@@ -733,7 +728,12 @@ class PageEvaluateResult(TypedDict):
     value: FieldSchema9
 
 
-PageEventName: TypeAlias = Literal["console"]
+PageEventName: TypeAlias = Literal["console", "requestfinished"]
+
+
+class PageEventNotification(TypedDict):
+    subscription_id: str
+    event: PageCDPEvent | NavigationResponseDescriptor
 
 
 class PageHoverParams(TypedDict):

--- a/packages/sdk-python/src/stagehand/_generated/models.py
+++ b/packages/sdk-python/src/stagehand/_generated/models.py
@@ -1482,15 +1482,6 @@ class PageCDPEvent(WireModel):
     target_id: Annotated[StrictStr, Field(min_length=1)]
 
 
-class PageCDPEventNotification(WireModel):
-    model_config = ConfigDict(
-        extra="forbid",
-        validate_by_name=True,
-    )
-    subscription_id: Annotated[StrictStr, Field(min_length=1)]
-    event: PageCDPEvent
-
-
 class PageCDPEventParams(RootModel[dict[StrictStr, Optional[FieldSchema12]]]):
     root: dict[StrictStr, Optional[FieldSchema12]]
 
@@ -1573,8 +1564,18 @@ class PageEvaluateResult(WireModel):
     value: Optional[FieldSchema9]
 
 
-class PageEventName(RootModel[Literal["console"]]):
-    root: Literal["console"]
+class PageEventName(StrEnum):
+    console = "console"
+    requestfinished = "requestfinished"
+
+
+class PageEventNotification(WireModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_by_name=True,
+    )
+    subscription_id: Annotated[StrictStr, Field(min_length=1)]
+    event: Union[PageCDPEvent, NavigationResponseDescriptor]
 
 
 class PageGoBackParams(WireModel):

--- a/packages/sdk-ts/src/page.ts
+++ b/packages/sdk-ts/src/page.ts
@@ -1,6 +1,6 @@
 import type {
   LoadState,
-  PageCDPEvent,
+  PageEvent,
   PageEventName,
   PageClickParams,
   PageDragAndDropParams,
@@ -21,6 +21,7 @@ import {
   StagehandMethods,
   StagehandNotifications,
 } from "@browserbasehq/stagehand-protocol/schema-registry";
+import { PageEventSchemas } from "@browserbasehq/stagehand-protocol/schemas";
 import { decodeBase64 } from "./base64.js";
 import { Locator } from "./locator.js";
 import {
@@ -46,8 +47,13 @@ export type PageSetViewportSizeOptions = NonNullable<PageSetViewportSizeParams["
 export type PageTypeOptions = NonNullable<PageTypeParams["options"]>;
 export type PageWaitForSelectorOptions = NonNullable<PageWaitForSelectorParams["options"]>;
 
-export interface PageEventListener {
-  (event: PageCDPEvent): unknown;
+export type PageEventPayload<E extends PageEventName> = {
+  console: PageEvent<"console">;
+  requestfinished: Response;
+}[E];
+
+export interface PageEventListener<E extends PageEventName> {
+  (event: PageEventPayload<E>): unknown;
 }
 
 export class CDPSubscription {
@@ -212,17 +218,38 @@ export class Page {
     });
   }
 
-  async on(event: PageEventName, listener: PageEventListener): Promise<CDPSubscription> {
+  async on<E extends PageEventName>(
+    event: E,
+    listener: PageEventListener<E>,
+  ): Promise<CDPSubscription> {
     const subscriptionId = crypto.randomUUID();
+    const eventSchema = PageEventSchemas[event];
     const removeNotificationListener = this.rpcClient.onNotification((notification) => {
       if (
-        notification.method !== StagehandNotifications.pageCDPEvent.name ||
+        notification.method !== StagehandNotifications.event.name ||
         notification.params.subscriptionId !== subscriptionId
       ) {
         return;
       }
+      const parsedEvent = eventSchema.safeParse(notification.params.event);
+      if (!parsedEvent.success) {
+        reportPageEventListenerError(parsedEvent.error);
+        return;
+      }
       try {
-        const result = listener(notification.params.event);
+        let eventPayload: PageEventPayload<E>;
+        if (event === "console") {
+          eventPayload = parsedEvent.data as PageEventPayload<E>;
+        } else if (event === "requestfinished") {
+          eventPayload = new Response(
+            this.rpcClient,
+            parsedEvent.data as any,
+          ) as PageEventPayload<E>;
+        } else {
+          reportPageEventListenerError(new Error(`Unsupported event type: ${event}`));
+          return;
+        }
+        const result = listener(eventPayload);
         if (result && typeof result === "object" && "then" in result) {
           void Promise.resolve(result).catch(reportPageEventListenerError);
         }


### PR DESCRIPTION
# why

Today, `page.on` can support more than `'console'` (per last change), but cannot support advanced class types as return values.

Put another way, it can only support _serializable_ objects sent over RPC. If we want the DX of `page.on` to return `() => SomeNiceUsableClass.withNiceMethods()`, we need to add type overloading for each language (Go/Python/TS).

# what changed

# test plan
