### PR TITLE
fix(extension): do not attach OTLP processor for placeholder example.com endpoint (#2732)

### DIFF
--- a/packages/extension/tracing.ts
+++ b/packages/extension/tracing.ts
@@ -119,6 +119,12 @@ export function createStagehandTracing(
         await previousRuntime?.shutdown();
 
         const registerGlobals = options.registerGlobals !== false && !globalsRegistered;
+        const isPlaceholderEndpoint = telemetry.traces.endpoint === "https://example.com/v1/traces";
+        const spanProcessors = [...dependencies.spanProcessors];
+        if (!isPlaceholderEndpoint) {
+          spanProcessors.push(createOtlpSpanProcessor(telemetry.traces));
+        }
+
         runtime = createStagehandTracingRuntime(
           {
             ...options,
@@ -127,10 +133,7 @@ export function createStagehandTracing(
             registerGlobals,
           },
           {
-            spanProcessors: [
-              ...dependencies.spanProcessors,
-              createOtlpSpanProcessor(telemetry.traces),
-            ],
+            spanProcessors,
           },
         );
         activeTelemetry = telemetry;


### PR DESCRIPTION
## Summary
- Fixes #2732
- In `packages/extension/tracing.ts`, avoid instantiating and attaching an `OTLPTraceExporter` / `BatchSpanProcessor` when `telemetry.traces.endpoint` is configured to the default placeholder `https://example.com/v1/traces`.
- Prevents guaranteed-failing network background requests and avoidable 5-second exporter timeouts during shutdown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2732 by skipping the OTLP trace processor when `telemetry.traces.endpoint` is the placeholder `https://example.com/v1/traces`. Previously the extension always attached the processor, causing guaranteed-failing background network requests and avoidable 5-second exporter timeouts during shutdown.

<sup>Written for commit 1aaaaaab67a3ae3be6235710b064c91587d31ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

