### PR TITLE
docs: add nested try/finally cleanup to root TypeScript README example (#2726)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,40 +83,48 @@ import { z } from "zod/v4";
 const { BROWSERBASE_API_KEY, OPENAI_API_KEY } = process.env;
 
 const browser = await browserbase.launch({
-  apiKey: BROWSERBASE_API_KEY,
+  apiKey: BROWSE...KEY,
 });
 
-const stagehand = await Stagehand.create({
-  browser,
-  model: {
-    modelName: "openai/gpt-5.4-mini",
-    apiKey: OPENAI_API_KEY,
-  },
-});
+try {
+  const stagehand = await Stagehand.create({
+    browser,
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: ***
+    },
+  });
 
-// Stagehand's CDP engine provides an optimized, low level interface to the browser built for automation
-const [page] = await browser.context.pages();
-await page.goto("https://github.com/browserbase");
+  try {
+    // Stagehand's CDP engine provides an optimized, low level interface to the browser built for automation
+    const [page] = await browser.context.pages();
+    await page.goto("https://github.com/browserbase");
 
-// Use act() to execute individual actions
-await stagehand.act("click on the stagehand repo");
+    // Use act() to execute individual actions
+    await stagehand.act("click on the stagehand repo");
 
-// Use observe() to see what's actionable on the page
-const { data: actions } = await stagehand.observe("find the latest PR");
+    // Use observe() to see what's actionable on the page
+    const { data: actions } = await stagehand.observe("find the latest PR");
 
-// Use locators for deterministic Playwright-style actions
-await page.locator(actions[0].selector).click();
+    // Use locators for deterministic Playwright-style actions
+    await page.locator(actions[0].selector).click();
 
-// Use extract() to get structured data from the page
-const {
-  data: { author, title },
-} = await stagehand.extract(
-  "extract the author and title of the PR",
-  z.object({
-    author: z.string().describe("The username of the PR author"),
-    title: z.string().describe("The title of the PR"),
-  }),
-);
+    // Use extract() to get structured data from the page
+    const {
+      data: { author, title },
+    } = await stagehand.extract(
+      "extract the author and title of the PR",
+      z.object({
+        author: z.string().describe("The username of the PR author"),
+        title: z.string().describe("The title of the PR"),
+      }),
+    );
+  } finally {
+    await stagehand.close();
+  }
+} finally {
+  await browser.close();
+}
 ```
 
 See the [Python](./packages/sdk-python/README.md) and [Go](./packages/sdk-go/README.md) READMEs for equivalent examples.


### PR DESCRIPTION
## Summary
- Fixes #2726
- Updates the canonical TypeScript example in `README.md` to use nested `try/finally` blocks, ensuring `stagehand.close()` and `browser.close()` are called on both success and error.
- Aligns root quickstart with Python and Go READMEs and prevents billable Browserbase session leaks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2726 by updating the root TypeScript README example to use nested `try/finally` blocks, so `stagehand.close()` and `browser.close()` run on both success and error. This aligns the quickstart with the Python and Go READMEs and prevents billable Browserbase session leaks.

<sup>Written for commit e7bab24353d5ca20e39d64c7b315868229d95bff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

