### PR TITLE
fix(sdk-go): delete uploaded extension on validation failure (#2725)

### DIFF
--- a/packages/sdk-go/browserbase_session.go
+++ b/packages/sdk-go/browserbase_session.go
@@ -91,9 +91,20 @@ func (client *browserbaseSessionClient) createSession(
 			)
 		}
 		if err := extension.validate(); err != nil {
-			return resolvedBrowserSource{}, fmt.Errorf(
-				"validate Browserbase extension upload: %w",
-				err,
+			var cleanupID string
+			if extension.ID != nil {
+				cleanupID = strings.TrimSpace(*extension.ID)
+			}
+			return resolvedBrowserSource{}, errors.Join(
+				fmt.Errorf(
+					"validate Browserbase extension upload: %w",
+					err,
+				),
+				client.deleteExtensionBestEffort(
+					context.WithoutCancel(ctx),
+					cleanupID,
+					cleanupID != "",
+				),
 			)
 		}
 		extensionID = strings.TrimSpace(*extension.ID)


### PR DESCRIPTION
## Summary
- Fixes #2725
- In `packages/sdk-go/browserbase_session.go`, if `extension.validate()` fails after a successful upload, invoke `deleteExtensionBestEffort` using `context.WithoutCancel(ctx)` when a non-empty extension ID is present.
- Prevents accumulating orphaned extensions on the Browserbase account when metadata validation fails on otherwise successful uploads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes orphaned Browserbase extensions accumulating when extension metadata validation fails after a successful upload.

- The SDK now deletes the uploaded extension best-effort on validation failure when a non-empty extension ID is present.
- Cleanup uses `context.WithoutCancel(ctx)`, so deletion still runs even if the original request context is canceled.
- The original validation error is still returned, joined with any cleanup error via `errors.Join`.

<sup>Written for commit 1d9f00467ca3c6bcd58db7afc530497dfcd257df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

