### PR TITLE
fix(extension): buffer early WebMCP.toolResponded events before command resolution (#2724)

### DIFF
--- a/packages/extension/understudy/page.ts
+++ b/packages/extension/understudy/page.ts
@@ -185,6 +185,7 @@ export class Page {
   readonly initScripts: string[] = [];
   extraHTTPHeaders: Record<string, string> = {};
   private readonly webMCPInvocations = new Map<string, WebMCPInvocationRecord>();
+  private readonly earlyWebMCPResponses = new Map<string, Protocol.WebMCP.ToolRespondedEvent>();
   private readonly webMCPResponseSessions = new Map<CDPSessionLike, WebMCPResponseSessionState>();
   private readonly cdpEventSubscriptions = new Set<CDPEventSubscription>();
 
@@ -193,7 +194,11 @@ export class Page {
     event: Protocol.WebMCP.ToolRespondedEvent,
   ): void {
     const record = this.webMCPInvocations.get(event.invocationId);
-    if (!record || record.session !== session || record.result !== undefined) return;
+    if (!record) {
+      this.earlyWebMCPResponses.set(event.invocationId, event);
+      return;
+    }
+    if (record.session !== session || record.result !== undefined) return;
 
     const result = webMCPToolResponse(event);
     record.result = result;
@@ -747,12 +752,25 @@ export class Page {
       this.removeWebMCPResponseListenerIfIdle(session);
       throw error;
     }
-    this.webMCPInvocations.set(response.invocationId, {
+    const invocationRecord: WebMCPInvocationRecord = {
       descriptor,
       session,
       deferred: createDeferred<WebMCPToolResponse>(),
-    });
+    };
+    this.webMCPInvocations.set(response.invocationId, invocationRecord);
     responseState.invocationIds.add(response.invocationId);
+
+    const earlyEvent = this.earlyWebMCPResponses.get(response.invocationId);
+    if (earlyEvent !== undefined) {
+      this.earlyWebMCPResponses.delete(response.invocationId);
+      const result = webMCPToolResponse(earlyEvent);
+      invocationRecord.result = result;
+      invocationRecord.deferred.resolve(result);
+      invocationRecord.retentionTimer = setTimeout(() => {
+        this.removeWebMCPInvocation(response.invocationId, invocationRecord);
+      }, WEBMCP_SETTLED_INVOCATION_RETENTION_MS);
+    }
+
     return descriptor;
   }
 


### PR DESCRIPTION
## Summary
- Fixes #2724
- In `packages/extension/understudy/page.ts`, buffer `WebMCP.toolResponded` events in `earlyWebMCPResponses` if they arrive before the `WebMCP.invokeTool` CDP command response settles.
- Flushes buffered completion event upon registration, resolving the race condition that causes `waitForWebMCPInvocationResult()` to hang indefinitely on fast tools.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Buffers `WebMCP.toolResponded` events that arrive before the `WebMCP.invokeTool` CDP command settles, so fast tools no longer cause `waitForWebMCPInvocationResult()` to hang indefinitely.

Fixes #2724.

<sup>Written for commit e465ecb193b5b9ac05e7bb0fc5f773ae9cc75fd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

