### PR TITLE
test(sdk-python): normalize path assertions for cross-platform compatibility (#2733)

### DIFF
--- a/packages/sdk-python/tests/test_browser.py
+++ b/packages/sdk-python/tests/test_browser.py
@@ -481,16 +481,17 @@ async def test_launch_configures_downloads_on_the_root_session(
         return source
 
     monkeypatch.setattr(browser, "_launch_local_browser", launch)
+    downloads_path = Path("/tmp/downloads")
     handle = await local_browser.launch(
-        downloads_path=Path("/tmp/downloads"),
+        downloads_path=downloads_path,
         accept_downloads=True,
     )
 
-    assert captured[-1].downloads_path == "/tmp/downloads"
+    assert captured[-1].downloads_path == str(downloads_path)
     assert fake_cdp.instances[-1].commands == [
         (
             "Browser.setDownloadBehavior",
-            {"behavior": "allow", "downloadPath": "/tmp/downloads"},
+            {"behavior": "allow", "downloadPath": str(downloads_path)},
         )
     ]
     await handle.close()
@@ -583,7 +584,9 @@ async def test_connect_uses_extension_id_or_packaged_extension_and_never_owns_so
     packaged = await local_browser.connect(cdp_url="http://browser")
     arguments = fake_cdp.connect_arguments[-1]
     assert arguments["extension_id"] is None
-    assert str(arguments["extension_dir"]).endswith(("stagehand/_extension", "extension/dist"))
+    assert Path(str(arguments["extension_dir"])).as_posix().endswith(
+        ("stagehand/_extension", "extension/dist")
+    )
     assert arguments["service_worker_url_includes"] == "service-worker.js"
     assert set(arguments) == {
         "cdp_url",


### PR DESCRIPTION
## Summary
- Fixes #2733
- Normalizes path assertions in `packages/sdk-python/tests/test_browser.py` using `str(downloads_path)` and `Path(...).as_posix()` so that test assertions pass on Windows without failing on native path separators.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2733 by normalizing path assertions in `packages/sdk-python/tests/test_browser.py` so tests pass on Windows instead of failing on native path separators. Replaces hardcoded POSIX paths with `str(downloads_path)` and `Path.as_posix()` conversions.

<sup>Written for commit 43674678698a79885bb4134ca924fd1b925735c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

