### PR TITLE
test: make runtime compatibility fixtures resilient to protocol bumps

### DIFF
--- a/packages/sdk-go/runtime_compatibility_test.go
+++ b/packages/sdk-go/runtime_compatibility_test.go
@@ -2,12 +2,20 @@ package stagehand
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 func TestNegotiateRuntimeCompatibility(t *testing.T) {
 	t.Parallel()
+
+	protocolMajor, err := strconv.Atoi(strings.Split(stagehandProtocolVersion, ".")[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	incompatibleProtocolVersion := fmt.Sprintf("%d.0.0", protocolMajor+1)
 
 	tests := []struct {
 		name       string
@@ -17,12 +25,12 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 	}{
 		{
 			name: "compatible",
-			marker: `{
-				"protocolVersion": "1.0.9",
+			marker: fmt.Sprintf(`{
+				"protocolVersion": %q,
 				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
-			}`,
+			}`, stagehandProtocolVersion),
 			compatible: true,
-			detail:     "protocolVersion=1.0.9",
+			detail:     "protocolVersion=" + stagehandProtocolVersion,
 		},
 		{
 			name:       "missing marker",
@@ -32,19 +40,19 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 		},
 		{
 			name: "major mismatch",
-			marker: `{
-				"protocolVersion": "2.0.0",
+			marker: fmt.Sprintf(`{
+				"protocolVersion": %q,
 				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
-			}`,
+			}`, incompatibleProtocolVersion),
 			compatible: false,
 			detail:     "major mismatch",
 		},
 		{
 			name: "wrong runtime",
-			marker: `{
-				"protocolVersion": "1.0.0",
+			marker: fmt.Sprintf(`{
+				"protocolVersion": %q,
 				"serverInfo": {"name": "other", "version": "1.0.0"}
-			}`,
+			}`, stagehandProtocolVersion),
 			compatible: false,
 			detail:     `serverInfo.name="other"`,
 		},

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -633,7 +633,7 @@ class TestNegotiateRuntime:
             ({}, "serverInfo.name=None"),
             (
                 {
-                    "protocolVersion": "2.0.0",
+                    "protocolVersion": f"{int(STAGEHAND_PROTOCOL_VERSION.split('.')[0]) + 1}.0.0",
                     "serverInfo": {"name": "stagehand", "version": "0"},
                 },
                 "major mismatch",

--- a/packages/sdk-ts/tests/cdpClientLifecycle.test.ts
+++ b/packages/sdk-ts/tests/cdpClientLifecycle.test.ts
@@ -17,6 +17,7 @@ type CdpCall = {
 };
 
 const lifecycleSignal = new AbortController().signal;
+const incompatibleProtocolVersion = `${Number(STAGEHAND_PROTOCOL_VERSION.split(".")[0]) + 1}.0.0`;
 
 type TargetInfo = {
   targetId: string;
@@ -395,7 +396,7 @@ describe("waitForRuntimeReady", () => {
     const controller = new AbortController();
     const reason = new Error("initialization cancelled");
     const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
-      result: { value: runtimeReadiness("2.0.0") },
+      result: { value: runtimeReadiness(incompatibleProtocolVersion) },
     }));
 
     const error = await rejectedError(
@@ -413,7 +414,7 @@ describe("waitForRuntimeReady", () => {
 
   it("throws for an out-of-range attached runtime when fallback installation is disabled", async () => {
     const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
-      result: { value: runtimeReadiness("2.0.0") },
+      result: { value: runtimeReadiness(incompatibleProtocolVersion) },
     }));
 
     await expect(


### PR DESCRIPTION
## Summary
- Fix the stale compatibility fixtures causing the TypeScript, Python, and Go failures on release PR #2798.
- Derive incompatible runtime versions from the current protocol major instead of hardcoding `2.0.0`.
- Use the current protocol version for Go compatible/wrong-runtime fixtures; keep explicit-version protocol comparison tests unchanged.
- Test-only changes. No runtime behavior or release version changes.

## Why
The release bumps the protocol from `1.0.0` to `2.0.0`. Tests that previously treated `2.0.0` as incompatible start accepting it, while the Go fixture treating `1.0.9` as compatible starts rejecting it. Deriving the fixtures from the current protocol avoids repeating this failure on future major releases.

## Validation
Passed with both the main protocol version (`1.0.0`) and a temporary release-equivalent bump (`2.0.0`) applied to the protocol package and generated Go/Python constants:
- TypeScript: `pnpm exec vitest run packages/sdk-ts/tests/cdpClientLifecycle.test.ts` — 19 passed.
- Python: `uv run --locked pytest tests/test_cdp_client.py -q` — 28 passed.
- Go: `go test . -run 'Test(NegotiateRuntimeCompatibility|ProtocolCompatibility)$' -count=1` — passed.

Also passed TypeScript oxfmt/oxlint, Python Ruff lint/format, Go gofmt, and `git diff --check`.

Temporary version bumps were reverted before committing. Full CI remains to run on this PR.

Merge this into main so the release PR can incorporate the corrected fixtures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stale runtime compatibility fixtures in the TypeScript, Python, and Go SDK tests that break when the protocol version bumps. Fixtures now derive incompatible versions from the current protocol major instead of hardcoding `2.0.0`.

- Go fixtures use the current `stagehandProtocolVersion` for compatible and wrong-runtime cases and compute the next major for the mismatch case.
- Python and TypeScript tests derive the incompatible version as the current protocol major plus one.
- Test-only change; no runtime behavior or release version changes.

<sup>Written for commit 46e7d4ab25f160e0a86487d456bff934aba684bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

