### PR TITLE
test: fix remaining release protocol handshake fixtures

### DIFF
--- a/packages/extension/tests/rpc-client.test.ts
+++ b/packages/extension/tests/rpc-client.test.ts
@@ -3,10 +3,14 @@ import { StackContextManager } from "@opentelemetry/sdk-trace-web";
 import { describe, expect, it, vi } from "vitest";
 import { JSONRPCRequestSchema } from "@browserbasehq/stagehand-protocol/json-rpc/schemas";
 import { StagehandMethods } from "@browserbasehq/stagehand-protocol/schema-registry";
+import { STAGEHAND_PROTOCOL_VERSION } from "@browserbasehq/stagehand-protocol/schemas";
 import { ChromeRuntimeClient } from "../clients/chromeRuntimeClient.ts";
 import { RPCClient } from "../clients/rpcClient.ts";
 import { createStagehandRuntime } from "../runtime.ts";
 import { RPCRouter } from "../rpcRouter.ts";
+
+const [protocolMajor, protocolMinor, protocolPatch] =
+  STAGEHAND_PROTOCOL_VERSION.split(".").map(Number);
 
 describe("worker RPCClient", () => {
   function createRuntime() {
@@ -315,10 +319,10 @@ describe("worker RPCClient", () => {
   });
 
   it.each([
-    ["1.0.9", true, undefined],
-    ["1.1.0", false, "protocol-server-too-old"],
-    ["2.0.0", false, "protocol-major-mismatch"],
-    ["1.0.0-beta.1", false, "protocol-prerelease-mismatch"],
+    [`${protocolMajor}.${protocolMinor}.${protocolPatch + 1}`, true, undefined],
+    [`${protocolMajor}.${protocolMinor + 1}.0`, false, "protocol-server-too-old"],
+    [`${protocolMajor + 1}.0.0`, false, "protocol-major-mismatch"],
+    [`${STAGEHAND_PROTOCOL_VERSION}-beta.1`, false, "protocol-prerelease-mismatch"],
   ] as const)(
     "negotiates client protocol %s through the stagehand.init wire handshake",
     async (protocolVersion, compatible, reason) => {

--- a/packages/extension/tests/rpc-router.test.ts
+++ b/packages/extension/tests/rpc-router.test.ts
@@ -21,6 +21,7 @@ import type { CdpWebSocketCloseEvent, CdpWebSocketTransport } from "../understud
 import type { Page } from "../understudy/page.ts";
 
 const EMPTY_METRICS = new StagehandMetricsAccumulator().snapshot();
+const [protocolMajor, protocolMinor] = STAGEHAND_PROTOCOL_VERSION.split(".").map(Number);
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -328,9 +329,9 @@ describe("Stagehand RPC router", () => {
   });
 
   it.each([
-    ["1.1.0", "protocol-server-too-old"],
-    ["2.0.0", "protocol-major-mismatch"],
-    ["1.0.0-beta.1", "protocol-prerelease-mismatch"],
+    [`${protocolMajor}.${protocolMinor + 1}.0`, "protocol-server-too-old"],
+    [`${protocolMajor + 1}.0.0`, "protocol-major-mismatch"],
+    [`${STAGEHAND_PROTOCOL_VERSION}-beta.1`, "protocol-prerelease-mismatch"],
   ] as const)("rejects incompatible client protocol %s", async (protocolVersion, reason) => {
     const initializeStagehand = vi.fn(async () => ({ initialized: true as const, pages: [] }));
     const router = new RPCRouter(createStagehandRuntime(), { initializeStagehand });


### PR DESCRIPTION
## Summary
- Finish the protocol-relative fixture updates missed in #2908.
- Derive extension RPC handshake fixtures from the current protocol version instead of hardcoding `1.0.9`, `1.1.0`, and `2.0.0`.
- Preserve coverage for patch compatibility, newer-client minor rejection, major mismatch, and prerelease mismatch without changing runtime behavior.

## Root cause
Release PR #2798 bumps the protocol to `2.0.0`. The extension tests still assumed a `1.0.0` server: `1.0.9` was expected to succeed, `1.1.0` was expected to fail specifically because the server minor was too old, and `2.0.0` was expected to fail with a major mismatch.

These five failures were already present in the original CI log; #2908 fixed the SDK-side fixtures but missed the extension-side fixtures. The refreshed release commit only adds #2908, so these are remaining failures rather than a new runtime regression.

## Validation
- Reproduced exactly five failures across `rpc-client.test.ts` and `rpc-router.test.ts` with protocol `2.0.0` before this patch.
- After the patch, both files pass all 25 tests with protocol `2.0.0`.
- Both files also pass all 25 tests with protocol `1.0.0` and a simulated future `2.3.4`.
- Full `pnpm exec turbo run test:unit --force` passes with protocol `2.0.0`: all 32 tasks succeed with no cache hits, including all 355 extension tests and 272 SDK tests (10 existing extension TODOs).
- Extension TypeScript typecheck, targeted oxlint/oxfmt, and `git diff --check` pass.

Temporary protocol version changes were reverted before committing. Test-only follow-up; no changeset or production version bump required. GitHub CI still needs to run on this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes extension RPC handshake tests that broke after the protocol version bumped to `2.0.0` by deriving test fixtures from the current protocol version.

**Bug Fixes**
- Hardcoded `1.0.9`, `1.1.0`, and `2.0.0` fixtures assumed a `1.0.0` server, causing five failures across `rpc-client.test.ts` and `rpc-router.test.ts`.
- Fixtures now use `STAGEHAND_PROTOCOL_VERSION`, so they stay in sync with future bumps.
- Patch compatibility, minor rejection, major mismatch, and prerelease mismatch coverage is preserved.
- Test-only change; no changeset or runtime impact.

<sup>Written for commit 733e907e1822d7f1041c25194f7870c4725ef4bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

