### PR TITLE
chore(release): v4.0 maintenance branch release workflow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "commit": false,
   "linked": [],
   "ignore": ["@browserbasehq/stagehand-evals"],
-  "baseBranch": "main",
+  "baseBranch": "v4.0",
   "updateInternalDependencies": "patch",
   "access": "public",
   "changelog": [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
+# v4.0 maintenance branch: stable releases only; alpha publishing is intentionally disabled here so it cannot move the alpha dist-tags owned by main.
 name: Release
 
 on:
   push:
     branches:
-      - main
+      - v4.0
 
 permissions:
   contents: write

--- a/packages/extension/tests/stagehand-clients.test.ts
+++ b/packages/extension/tests/stagehand-clients.test.ts
@@ -9,6 +9,7 @@ import {
   StagehandSendToHostBindingSchema,
 } from "../../protocol/schema-registry.ts";
 import { startStagehandServiceWorker } from "../service-worker.ts";
+import { STAGEHAND_RUNTIME_VERSION } from "../version.ts";
 import type {
   StagehandBrowserSession,
   UnderstudyRuntimeClipboardOptions,
@@ -804,7 +805,7 @@ describe("Stagehand worker clients", () => {
         protocolVersion: STAGEHAND_PROTOCOL_VERSION,
         serverInfo: {
           name: "stagehand",
-          version: "1.0.0",
+          version: STAGEHAND_RUNTIME_VERSION,
         },
       },
       __stagehandReceiveFromHost: expect.any(Function),


### PR DESCRIPTION
## Why this branch exists

`v4.0` was cut from tag `@browserbasehq/stagehand@4.0.2` so we can ship a **4.0.3 fail-fast patch** ahead of 4.1.0 without pulling in everything that has landed on `main` since. For that to work, the branch has to be able to release itself: the Release workflow on `main` only triggers on pushes to `main`, so merges into `v4.0` would never open a release PR or publish.

## What changed

- `.github/workflows/release.yml`
  - push trigger: `branches: [main]` -> `branches: [v4.0]`
  - header comment documenting that this is the v4.0 maintenance-branch workflow (stable releases only)
  - everything else byte-identical
- `.changeset/config.json`: `baseBranch: "main"` -> `"v4.0"` so `changeset status`/`version` diff against the right base

No package versions bumped, no changeset (workflow-only change).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes v4.0 a self-releasing maintenance branch and fixes a test fixture that was red on the 4.0.2 tag.

- Release workflow triggers on pushes to `v4.0`; alpha publishing stays disabled so `main` keeps owning alpha dist-tags.
- Changeset base branch updated to `v4.0` so versioning diffs against the right base.
- `stagehand-clients.test.ts` now derives the runtime version from the package instead of hardcoding `1.0.0`, which broke after the 4.0.2 bump.

<sup>Written for commit 5a9fceb651bcebe4eb0d68139af7277732ceabe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



