### PR TITLE
[fix]: fail fast on incompatible Stagehand runtime instead of polling to timeout

### DIFF
--- a/.changeset/fail-fast-incompatible-runtime.md
+++ b/.changeset/fail-fast-incompatible-runtime.md
@@ -4,4 +4,4 @@
 "@browserbasehq/stagehand-go": patch
 ---
 
-Fail fast with a protocol compatibility error when the connected Stagehand extension reports an incompatible protocol version, instead of polling until the initialization timeout.
+Fail fast on protocol compatibility errors

--- a/.changeset/fail-fast-incompatible-runtime.md
+++ b/.changeset/fail-fast-incompatible-runtime.md
@@ -1,0 +1,7 @@
+---
+"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand-python": patch
+"@browserbasehq/stagehand-go": patch
+---
+
+Fail fast with a protocol compatibility error when the connected Stagehand extension reports an incompatible protocol version, instead of polling until the initialization timeout.

--- a/packages/sdk-go/cdp_client.go
+++ b/packages/sdk-go/cdp_client.go
@@ -65,6 +65,11 @@ type cdpClientOptions struct {
 	pollInterval             time.Duration
 	activationDelay          time.Duration
 	httpClient               *http.Client
+	// allowFallbackInstall is reserved for flows that can replace an
+	// incompatible preloaded extension. When false (the default) an
+	// incompatible runtime marker fails initialization on the first poll
+	// instead of polling until the initialization deadline.
+	allowFallbackInstall bool
 }
 
 type cdpClient struct {
@@ -377,6 +382,7 @@ func (c *cdpClient) initialize(ctx context.Context, options cdpClientOptions) er
 		ctx,
 		sessionID,
 		options.pollInterval,
+		options.allowFallbackInstall,
 	)
 }
 
@@ -962,6 +968,7 @@ func (c *cdpClient) waitForRuntimeReady(
 	ctx context.Context,
 	sessionID string,
 	pollInterval time.Duration,
+	allowFallbackInstall bool,
 ) error {
 	lastError := ""
 	for {
@@ -978,9 +985,12 @@ func (c *cdpClient) waitForRuntimeReady(
 				err,
 			)
 		}
-		ready, detail := c.evaluateRuntimeReadiness(ctx, sessionID)
+		ready, incompatible, detail := c.evaluateRuntimeReadiness(ctx, sessionID)
 		if ready {
 			return nil
+		}
+		if incompatible != nil && !allowFallbackInstall {
+			return incompatible
 		}
 		lastError = detail
 		if err := waitForCDPPoll(ctx, pollInterval); err != nil {
@@ -989,10 +999,14 @@ func (c *cdpClient) waitForRuntimeReady(
 	}
 }
 
+// evaluateRuntimeReadiness reports whether the runtime is ready. When the
+// marker is present but incompatible it also returns the typed error so the
+// caller can stop polling; detail always describes why the runtime is not
+// ready yet.
 func (c *cdpClient) evaluateRuntimeReadiness(
 	ctx context.Context,
 	sessionID string,
-) (bool, string) {
+) (ready bool, incompatible *RuntimeIncompatibleError, detail string) {
 	var evaluated cdpRuntimeEvaluateResult
 	err := c.sendCommand(
 		ctx,
@@ -1005,30 +1019,34 @@ func (c *cdpClient) evaluateRuntimeReadiness(
 		&evaluated,
 	)
 	if err != nil {
-		return false, err.Error()
+		return false, nil, err.Error()
 	}
 	if evaluated.ExceptionDetails != nil {
-		return false, runtimeExceptionMessage(
+		return false, nil, runtimeExceptionMessage(
 			evaluated.ExceptionDetails,
 			"readiness evaluation threw",
 		)
 	}
 	if evaluated.Result == nil || len(evaluated.Result.Value) == 0 {
-		return false, "readiness evaluation returned no value"
+		return false, nil, "readiness evaluation returned no value"
 	}
 	var readiness cdpRuntimeReadiness
 	if err := json.Unmarshal(evaluated.Result.Value, &readiness); err != nil {
-		return false, "readiness evaluation returned an invalid value"
+		return false, nil, "readiness evaluation returned an invalid value"
 	}
-	compatible, detail := negotiateRuntimeCompatibility(readiness.Marker)
-	if compatible && readiness.HasReceiver {
-		return true, ""
+	negotiation := negotiateRuntimeCompatibility(readiness.Marker)
+	if negotiation.compatible() && readiness.HasReceiver {
+		return true, nil, ""
 	}
-	return false, fmt.Sprintf(
+	detail = fmt.Sprintf(
 		"runtime %s, __stagehandReceiveFromHost=%t",
-		detail,
+		negotiation.detail,
 		readiness.HasReceiver,
 	)
+	if negotiation.kind == runtimeIncompatible {
+		return false, negotiation.incompatibleError(), detail
+	}
+	return false, nil, detail
 }
 
 func (c *cdpClient) bestEffortCommand(ctx context.Context, method string, params any) {

--- a/packages/sdk-go/cdp_client_test.go
+++ b/packages/sdk-go/cdp_client_test.go
@@ -467,9 +467,15 @@ func TestWaitForRuntimeReadyFailsFastOnIncompatibleRuntime(t *testing.T) {
 		runtimeReadinessResponse(runtimeMarker(incompatibleVersion, stagehandRuntimeName), true),
 	)
 
-	// A generous poll interval proves the error is returned before any re-poll wait.
+	// A generous poll interval proves the error is returned before any re-poll wait; the
+	// bounded context turns a regression that keeps polling into a fast, explicit failure.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	started := time.Now()
-	err := client.waitForRuntimeReady(context.Background(), "worker-session", time.Hour, false)
+	err := client.waitForRuntimeReady(ctx, "worker-session", time.Hour, false)
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("waitForRuntimeReady() kept polling an incompatible runtime instead of failing fast")
+	}
 	if err == nil {
 		t.Fatal("waitForRuntimeReady() error = nil, want RuntimeIncompatibleError")
 	}
@@ -515,7 +521,12 @@ func TestWaitForRuntimeReadyFailsFastOnForeignRuntime(t *testing.T) {
 		runtimeReadinessResponse(runtimeMarker(stagehandProtocolVersion, "other"), true),
 	)
 
-	err := client.waitForRuntimeReady(context.Background(), "worker-session", time.Hour, false)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.waitForRuntimeReady(ctx, "worker-session", time.Hour, false)
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("waitForRuntimeReady() kept polling a foreign runtime instead of failing fast")
+	}
 	var incompatible *RuntimeIncompatibleError
 	if !errors.As(err, &incompatible) {
 		t.Fatalf("waitForRuntimeReady() error = %v, want *RuntimeIncompatibleError", err)

--- a/packages/sdk-go/cdp_client_test.go
+++ b/packages/sdk-go/cdp_client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -400,6 +401,186 @@ func TestCDPClientInitializesLoadedExtension(t *testing.T) {
 	}
 	if !reflect.DeepEqual(actualMethods, expectedMethods) {
 		t.Fatalf("CDP methods = %#v, want %#v", actualMethods, expectedMethods)
+	}
+}
+
+func incompatibleProtocolVersionForTest(t *testing.T) string {
+	t.Helper()
+	protocolMajor, err := strconv.Atoi(strings.Split(stagehandProtocolVersion, ".")[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("%d.0.0", protocolMajor+1)
+}
+
+func runtimeReadinessResponse(marker map[string]any, hasReceiver bool) map[string]any {
+	value := map[string]any{"hasReceiver": hasReceiver}
+	if marker == nil {
+		value["marker"] = nil
+	} else {
+		value["marker"] = marker
+	}
+	return map[string]any{"result": map[string]any{
+		"result": map[string]any{"value": value},
+	}}
+}
+
+func runtimeMarker(protocolVersion string, name string) map[string]any {
+	return map[string]any{
+		"protocolVersion": protocolVersion,
+		"serverInfo":      map[string]any{"name": name, "version": "1.0.0"},
+	}
+}
+
+// readinessSequence answers Runtime.evaluate with each response in order and
+// repeats the last one forever.
+func readinessSequence(
+	t *testing.T,
+	socket *fakeCDPWebSocket,
+	responses ...map[string]any,
+) (*cdpClient, *atomic.Int32) {
+	t.Helper()
+	var evaluations atomic.Int32
+	socket.writeHook = responseHook(t, socket, nil, func(
+		method string,
+		_ map[string]json.RawMessage,
+	) map[string]any {
+		if method != "Runtime.evaluate" {
+			return map[string]any{"result": map[string]any{}}
+		}
+		index := int(evaluations.Add(1)) - 1
+		if index >= len(responses) {
+			index = len(responses) - 1
+		}
+		return responses[index]
+	})
+	return newTestCDPClient(t, socket, "ws://127.0.0.1/devtools/browser/test"), &evaluations
+}
+
+func TestWaitForRuntimeReadyFailsFastOnIncompatibleRuntime(t *testing.T) {
+	t.Parallel()
+
+	incompatibleVersion := incompatibleProtocolVersionForTest(t)
+	client, evaluations := readinessSequence(
+		t,
+		newFakeCDPWebSocket(),
+		runtimeReadinessResponse(runtimeMarker(incompatibleVersion, stagehandRuntimeName), true),
+	)
+
+	// A generous poll interval proves the error is returned before any re-poll wait.
+	started := time.Now()
+	err := client.waitForRuntimeReady(context.Background(), "worker-session", time.Hour, false)
+	if err == nil {
+		t.Fatal("waitForRuntimeReady() error = nil, want RuntimeIncompatibleError")
+	}
+	var incompatible *RuntimeIncompatibleError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("waitForRuntimeReady() error = %v, want *RuntimeIncompatibleError", err)
+	}
+	if incompatible.Reason != "protocol-major-mismatch" {
+		t.Fatalf("Reason = %q", incompatible.Reason)
+	}
+	if incompatible.ClientProtocolVersion != stagehandProtocolVersion {
+		t.Fatalf("ClientProtocolVersion = %q", incompatible.ClientProtocolVersion)
+	}
+	if incompatible.ReportedProtocolVersion != incompatibleVersion {
+		t.Fatalf("ReportedProtocolVersion = %q", incompatible.ReportedProtocolVersion)
+	}
+	if incompatible.ServerInfo != (ImplementationInfo{Name: stagehandRuntimeName, Version: "1.0.0"}) {
+		t.Fatalf("ServerInfo = %#v", incompatible.ServerInfo)
+	}
+	for _, want := range []string{
+		"client protocol " + stagehandProtocolVersion,
+		"reported protocol " + incompatibleVersion,
+		"Upgrade the Stagehand SDK and the Stagehand extension",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err.Error(), want)
+		}
+	}
+	if got := evaluations.Load(); got != 1 {
+		t.Fatalf("Runtime.evaluate calls = %d, want 1", got)
+	}
+	if elapsed := time.Since(started); elapsed > 10*time.Second {
+		t.Fatalf("waitForRuntimeReady() waited %s before failing", elapsed)
+	}
+}
+
+func TestWaitForRuntimeReadyFailsFastOnForeignRuntime(t *testing.T) {
+	t.Parallel()
+
+	client, evaluations := readinessSequence(
+		t,
+		newFakeCDPWebSocket(),
+		runtimeReadinessResponse(runtimeMarker(stagehandProtocolVersion, "other"), true),
+	)
+
+	err := client.waitForRuntimeReady(context.Background(), "worker-session", time.Hour, false)
+	var incompatible *RuntimeIncompatibleError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("waitForRuntimeReady() error = %v, want *RuntimeIncompatibleError", err)
+	}
+	if incompatible.Reason != "runtime-name-mismatch" {
+		t.Fatalf("Reason = %q", incompatible.Reason)
+	}
+	if incompatible.ServerInfo.Name != "other" {
+		t.Fatalf("ServerInfo.Name = %q", incompatible.ServerInfo.Name)
+	}
+	if got := evaluations.Load(); got != 1 {
+		t.Fatalf("Runtime.evaluate calls = %d, want 1", got)
+	}
+}
+
+func TestWaitForRuntimeReadyKeepsPollingUnknownMarkerUntilCompatible(t *testing.T) {
+	t.Parallel()
+
+	client, evaluations := readinessSequence(
+		t,
+		newFakeCDPWebSocket(),
+		runtimeReadinessResponse(nil, false),
+		runtimeReadinessResponse(nil, false),
+		runtimeReadinessResponse(nil, true),
+		readyRuntimeResponse(),
+	)
+
+	err := client.waitForRuntimeReady(
+		context.Background(),
+		"worker-session",
+		time.Millisecond,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("waitForRuntimeReady() error = %v", err)
+	}
+	if got := evaluations.Load(); got != 4 {
+		t.Fatalf("Runtime.evaluate calls = %d, want 4", got)
+	}
+}
+
+func TestWaitForRuntimeReadyKeepsPollingIncompatibleRuntimeWhenFallbackAllowed(t *testing.T) {
+	t.Parallel()
+
+	client, evaluations := readinessSequence(
+		t,
+		newFakeCDPWebSocket(),
+		runtimeReadinessResponse(
+			runtimeMarker(incompatibleProtocolVersionForTest(t), stagehandRuntimeName),
+			true,
+		),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	err := client.waitForRuntimeReady(ctx, "worker-session", time.Millisecond, true)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waitForRuntimeReady() error = %v, want context deadline", err)
+	}
+	var incompatible *RuntimeIncompatibleError
+	if errors.As(err, &incompatible) {
+		t.Fatalf("waitForRuntimeReady() returned RuntimeIncompatibleError with fallback allowed")
+	}
+	if got := evaluations.Load(); got < 2 {
+		t.Fatalf("Runtime.evaluate calls = %d, want at least 2", got)
 	}
 }
 

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -122,7 +122,7 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeNegotiation {
 	}
 
 	var protocolVersion string
-	if err := json.Unmarshal(marker["protocolVersion"], &protocolVersion); err != nil {
+	if err := json.Unmarshal(marker["protocolVersion"], &protocolVersion); err != nil || protocolVersion == "" {
 		return unknownRuntime(fmt.Sprintf(
 			"protocolVersion=%s",
 			rawJSONDescription(marker["protocolVersion"]),
@@ -137,7 +137,8 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeNegotiation {
 		negotiation.kind = runtimeIncompatible
 		negotiation.reason = "runtime-name-mismatch"
 		negotiation.detail = fmt.Sprintf(
-			"Connected runtime is not Stagehand: serverInfo.name=%q",
+			"Runtime name mismatch: expected %q, server reported %q",
+			stagehandRuntimeName,
 			serverInfo.Name,
 		)
 		return negotiation

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -14,42 +14,148 @@ const (
 	stagehandSDKClientName = "stagehand-sdk-go"
 )
 
+// RuntimeIncompatibleRemediation is the one-line hint appended to
+// RuntimeIncompatibleError messages.
+const RuntimeIncompatibleRemediation = "Upgrade the Stagehand SDK and the Stagehand extension " +
+	"together so their protocol majors match, or start the session with the extension bundled " +
+	"in this SDK."
+
+// RuntimeIncompatibleError reports that the connected Stagehand extension
+// publishes a runtime this SDK can never talk to. It is returned on the first
+// readiness poll that observes the incompatible marker rather than after the
+// initialization timeout, because the extension will not change its protocol
+// version while the session is open. Use errors.As to inspect it.
+type RuntimeIncompatibleError struct {
+	// Reason is one of protocol-major-mismatch, protocol-server-too-old,
+	// protocol-prerelease-mismatch, protocol-invalid-version or
+	// runtime-name-mismatch.
+	Reason string
+	// ClientProtocolVersion is the protocol version this SDK speaks.
+	ClientProtocolVersion string
+	// ReportedProtocolVersion is the protocol version the extension published.
+	ReportedProtocolVersion string
+	// ServerInfo is the extension's own name and version.
+	ServerInfo ImplementationInfo
+	// Detail is the human-readable negotiation failure.
+	Detail string
+	// Remediation is a one-line hint on how to fix the mismatch.
+	Remediation string
+}
+
+func (e *RuntimeIncompatibleError) Error() string {
+	return fmt.Sprintf(
+		"incompatible Stagehand runtime: %s; client protocol %s, reported protocol %s, server %s/%s. %s",
+		e.Detail,
+		e.ClientProtocolVersion,
+		e.ReportedProtocolVersion,
+		e.ServerInfo.Name,
+		e.ServerInfo.Version,
+		e.Remediation,
+	)
+}
+
+type runtimeCompatibilityKind string
+
+const (
+	// runtimeCompatible: the marker parsed and this client can talk to it.
+	runtimeCompatible runtimeCompatibilityKind = "compatible"
+	// runtimeIncompatible: the marker parsed but this client can never talk
+	// to it, so polling further is pointless.
+	runtimeIncompatible runtimeCompatibilityKind = "incompatible"
+	// runtimeUnknown: the marker is absent or not yet readable; keep polling.
+	runtimeUnknown runtimeCompatibilityKind = "unknown"
+)
+
+type runtimeNegotiation struct {
+	kind            runtimeCompatibilityKind
+	reason          string
+	detail          string
+	protocolVersion string
+	serverInfo      ImplementationInfo
+}
+
+func (n runtimeNegotiation) compatible() bool {
+	return n.kind == runtimeCompatible
+}
+
+func (n runtimeNegotiation) incompatibleError() *RuntimeIncompatibleError {
+	return &RuntimeIncompatibleError{
+		Reason:                  n.reason,
+		ClientProtocolVersion:   stagehandProtocolVersion,
+		ReportedProtocolVersion: n.protocolVersion,
+		ServerInfo:              n.serverInfo,
+		Detail:                  n.detail,
+		Remediation:             RuntimeIncompatibleRemediation,
+	}
+}
+
+func unknownRuntime(detail string) runtimeNegotiation {
+	return runtimeNegotiation{kind: runtimeUnknown, detail: detail}
+}
+
 // negotiateRuntimeCompatibility deliberately mirrors the TypeScript and
 // Python clients. The runtime marker is transport state, while ServerInfo
 // reuses the protocol-generated ImplementationInfo struct.
-func negotiateRuntimeCompatibility(raw json.RawMessage) (bool, string) {
+func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeNegotiation {
 	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
-		return false, "no Stagehand runtime marker"
+		return unknownRuntime("no Stagehand runtime marker")
 	}
 
 	var marker map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &marker); err != nil {
-		return false, "unreadable Stagehand runtime marker"
+		return unknownRuntime("unreadable Stagehand runtime marker")
 	}
 
 	var serverInfo ImplementationInfo
 	if err := json.Unmarshal(marker["serverInfo"], &serverInfo); err != nil {
-		return false, "serverInfo.name=<nil>"
+		return unknownRuntime("serverInfo.name=<nil>")
 	}
-	if serverInfo.Name != stagehandRuntimeName {
-		return false, fmt.Sprintf("serverInfo.name=%q", serverInfo.Name)
+	if serverInfo.Name == "" || serverInfo.Version == "" {
+		return unknownRuntime(fmt.Sprintf("serverInfo.name=%q", serverInfo.Name))
 	}
 
 	var protocolVersion string
 	if err := json.Unmarshal(marker["protocolVersion"], &protocolVersion); err != nil {
-		return false, fmt.Sprintf(
+		return unknownRuntime(fmt.Sprintf(
 			"protocolVersion=%s",
 			rawJSONDescription(marker["protocolVersion"]),
-		)
+		))
 	}
-	return protocolCompatibility(stagehandProtocolVersion, protocolVersion)
+
+	negotiation := runtimeNegotiation{
+		protocolVersion: protocolVersion,
+		serverInfo:      serverInfo,
+	}
+	if serverInfo.Name != stagehandRuntimeName {
+		negotiation.kind = runtimeIncompatible
+		negotiation.reason = "runtime-name-mismatch"
+		negotiation.detail = fmt.Sprintf(
+			"connected runtime is not Stagehand: serverInfo.name=%q",
+			serverInfo.Name,
+		)
+		return negotiation
+	}
+
+	compatible, reason, detail := protocolCompatibility(stagehandProtocolVersion, protocolVersion)
+	negotiation.detail = detail
+	if !compatible {
+		negotiation.kind = runtimeIncompatible
+		negotiation.reason = reason
+		return negotiation
+	}
+	negotiation.kind = runtimeCompatible
+	return negotiation
 }
 
-func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) (bool, string) {
+// protocolCompatibility returns whether the versions are compatible plus the
+// machine-readable reason (empty when compatible) and a human-readable detail.
+func protocolCompatibility(
+	clientProtocolVersion, serverProtocolVersion string,
+) (compatible bool, reason string, detail string) {
 	clientVersion := "v" + clientProtocolVersion
 	serverVersion := "v" + serverProtocolVersion
 	if !validProtocolVersion(clientProtocolVersion) || !validProtocolVersion(serverProtocolVersion) {
-		return false, fmt.Sprintf(
+		return false, "protocol-invalid-version", fmt.Sprintf(
 			"invalid protocol version: client=%q server=%q",
 			clientProtocolVersion,
 			serverProtocolVersion,
@@ -57,16 +163,16 @@ func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) 
 	}
 	if semver.Prerelease(clientVersion) != "" || semver.Prerelease(serverVersion) != "" {
 		if serverProtocolVersion != clientProtocolVersion {
-			return false, fmt.Sprintf(
+			return false, "protocol-prerelease-mismatch", fmt.Sprintf(
 				"protocol prereleases must match exactly: client=%s server=%s",
 				clientProtocolVersion,
 				serverProtocolVersion,
 			)
 		}
-		return true, fmt.Sprintf("protocolVersion=%s", serverProtocolVersion)
+		return true, "", fmt.Sprintf("protocolVersion=%s", serverProtocolVersion)
 	}
 	if semver.Major(clientVersion) != semver.Major(serverVersion) {
-		return false, fmt.Sprintf(
+		return false, "protocol-major-mismatch", fmt.Sprintf(
 			"protocol major mismatch: client=%s server=%s",
 			clientProtocolVersion,
 			serverProtocolVersion,
@@ -75,14 +181,14 @@ func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) 
 	clientMinor := semver.MajorMinor(clientVersion) + ".0"
 	serverMinor := semver.MajorMinor(serverVersion) + ".0"
 	if semver.Compare(serverMinor, clientMinor) < 0 {
-		return false, fmt.Sprintf(
+		return false, "protocol-server-too-old", fmt.Sprintf(
 			"server protocol %s is older than client requirement %s",
 			serverProtocolVersion,
 			clientProtocolVersion,
 		)
 	}
 
-	return true, fmt.Sprintf("protocolVersion=%s", serverProtocolVersion)
+	return true, "", fmt.Sprintf("protocolVersion=%s", serverProtocolVersion)
 }
 
 func validProtocolVersion(version string) bool {

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -106,12 +106,19 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeNegotiation {
 		return unknownRuntime("unreadable Stagehand runtime marker")
 	}
 
+	// Mirrors the protocol's ImplementationInfoSchema: both fields are non-empty
+	// strings. A marker missing either is malformed, not a foreign runtime, so
+	// keep polling.
 	var serverInfo ImplementationInfo
 	if err := json.Unmarshal(marker["serverInfo"], &serverInfo); err != nil {
 		return unknownRuntime("serverInfo.name=<nil>")
 	}
 	if serverInfo.Name == "" || serverInfo.Version == "" {
-		return unknownRuntime(fmt.Sprintf("serverInfo.name=%q", serverInfo.Name))
+		return unknownRuntime(fmt.Sprintf(
+			"serverInfo.name=%q serverInfo.version=%q",
+			serverInfo.Name,
+			serverInfo.Version,
+		))
 	}
 
 	var protocolVersion string
@@ -130,7 +137,7 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeNegotiation {
 		negotiation.kind = runtimeIncompatible
 		negotiation.reason = "runtime-name-mismatch"
 		negotiation.detail = fmt.Sprintf(
-			"connected runtime is not Stagehand: serverInfo.name=%q",
+			"Connected runtime is not Stagehand: serverInfo.name=%q",
 			serverInfo.Name,
 		)
 		return negotiation
@@ -156,7 +163,7 @@ func protocolCompatibility(
 	serverVersion := "v" + serverProtocolVersion
 	if !validProtocolVersion(clientProtocolVersion) || !validProtocolVersion(serverProtocolVersion) {
 		return false, "protocol-invalid-version", fmt.Sprintf(
-			"invalid protocol version: client=%q server=%q",
+			"Invalid protocol version: client %s, server %s",
 			clientProtocolVersion,
 			serverProtocolVersion,
 		)
@@ -164,7 +171,7 @@ func protocolCompatibility(
 	if semver.Prerelease(clientVersion) != "" || semver.Prerelease(serverVersion) != "" {
 		if serverProtocolVersion != clientProtocolVersion {
 			return false, "protocol-prerelease-mismatch", fmt.Sprintf(
-				"protocol prereleases must match exactly: client=%s server=%s",
+				"Protocol prereleases must match exactly: client %s, server %s",
 				clientProtocolVersion,
 				serverProtocolVersion,
 			)
@@ -173,7 +180,7 @@ func protocolCompatibility(
 	}
 	if semver.Major(clientVersion) != semver.Major(serverVersion) {
 		return false, "protocol-major-mismatch", fmt.Sprintf(
-			"protocol major mismatch: client=%s server=%s",
+			"Protocol major mismatch: client %s, server %s",
 			clientProtocolVersion,
 			serverProtocolVersion,
 		)
@@ -182,7 +189,7 @@ func protocolCompatibility(
 	serverMinor := semver.MajorMinor(serverVersion) + ".0"
 	if semver.Compare(serverMinor, clientMinor) < 0 {
 		return false, "protocol-server-too-old", fmt.Sprintf(
-			"server protocol %s is older than client requirement %s",
+			"Server protocol %s is older than client requirement %s",
 			serverProtocolVersion,
 			clientProtocolVersion,
 		)

--- a/packages/sdk-go/runtime_compatibility_test.go
+++ b/packages/sdk-go/runtime_compatibility_test.go
@@ -46,6 +46,51 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			detail: "serverInfo.name=",
 		},
 		{
+			name: "null serverInfo",
+			marker: fmt.Sprintf(`{
+				"protocolVersion": %q,
+				"serverInfo": null
+			}`, stagehandProtocolVersion),
+			kind:   runtimeUnknown,
+			detail: `serverInfo.name=""`,
+		},
+		{
+			name: "non-object serverInfo",
+			marker: fmt.Sprintf(`{
+				"protocolVersion": %q,
+				"serverInfo": "stagehand"
+			}`, stagehandProtocolVersion),
+			kind:   runtimeUnknown,
+			detail: "serverInfo.name=<nil>",
+		},
+		{
+			name: "empty server name",
+			marker: fmt.Sprintf(`{
+				"protocolVersion": %q,
+				"serverInfo": {"name": "", "version": "1.0.0"}
+			}`, stagehandProtocolVersion),
+			kind:   runtimeUnknown,
+			detail: `serverInfo.name=""`,
+		},
+		{
+			name: "empty server version",
+			marker: fmt.Sprintf(`{
+				"protocolVersion": %q,
+				"serverInfo": {"name": "stagehand", "version": ""}
+			}`, stagehandProtocolVersion),
+			kind:   runtimeUnknown,
+			detail: `serverInfo.version=""`,
+		},
+		{
+			name: "missing server version",
+			marker: fmt.Sprintf(`{
+				"protocolVersion": %q,
+				"serverInfo": {"name": "stagehand"}
+			}`, stagehandProtocolVersion),
+			kind:   runtimeUnknown,
+			detail: `serverInfo.version=""`,
+		},
+		{
 			name: "major mismatch",
 			marker: fmt.Sprintf(`{
 				"protocolVersion": %q,
@@ -53,7 +98,11 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			}`, incompatibleProtocolVersion),
 			kind:   runtimeIncompatible,
 			reason: "protocol-major-mismatch",
-			detail: "major mismatch",
+			detail: fmt.Sprintf(
+				"Protocol major mismatch: client %s, server %s",
+				stagehandProtocolVersion,
+				incompatibleProtocolVersion,
+			),
 		},
 		{
 			name: "wrong runtime",
@@ -63,7 +112,7 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			}`, stagehandProtocolVersion),
 			kind:   runtimeIncompatible,
 			reason: "runtime-name-mismatch",
-			detail: `serverInfo.name="other"`,
+			detail: `Connected runtime is not Stagehand: serverInfo.name="other"`,
 		},
 		{
 			name: "invalid protocol version",
@@ -82,7 +131,10 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			}`,
 			kind:   runtimeIncompatible,
 			reason: "protocol-invalid-version",
-			detail: "invalid protocol version",
+			detail: fmt.Sprintf(
+				"Invalid protocol version: client %s, server not-semver",
+				stagehandProtocolVersion,
+			),
 		},
 	}
 
@@ -122,12 +174,13 @@ func TestProtocolCompatibility(t *testing.T) {
 	}{
 		{name: "patch ignored", client: "1.2.4", server: "1.2.0", compatible: true},
 		{name: "newer server minor", client: "1.2.4", server: "1.9.0", compatible: true},
-		{name: "server too old", client: "1.2.4", server: "1.1.99", reason: "protocol-server-too-old", detail: "older"},
-		{name: "major mismatch", client: "1.2.4", server: "2.0.0", reason: "protocol-major-mismatch", detail: "major mismatch"},
+		// Detail wording is the TS SDK's compatibilityDetail; keep the SDKs identical.
+		{name: "server too old", client: "1.2.4", server: "1.1.99", reason: "protocol-server-too-old", detail: "Server protocol 1.1.99 is older than client requirement 1.2.4"},
+		{name: "major mismatch", client: "1.2.4", server: "2.0.0", reason: "protocol-major-mismatch", detail: "Protocol major mismatch: client 1.2.4, server 2.0.0"},
 		{name: "exact prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.1", compatible: true},
-		{name: "different prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.2", reason: "protocol-prerelease-mismatch", detail: "match exactly"},
-		{name: "invalid client", client: "not-semver", server: "1.3.0", reason: "protocol-invalid-version", detail: "invalid protocol version"},
-		{name: "invalid server", client: "1.3.0", server: "not-semver", reason: "protocol-invalid-version", detail: "invalid protocol version"},
+		{name: "different prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.2", reason: "protocol-prerelease-mismatch", detail: "Protocol prereleases must match exactly: client 1.3.0-beta.1, server 1.3.0-beta.2"},
+		{name: "invalid client", client: "not-semver", server: "1.3.0", reason: "protocol-invalid-version", detail: "Invalid protocol version: client not-semver, server 1.3.0"},
+		{name: "invalid server", client: "1.3.0", server: "not-semver", reason: "protocol-invalid-version", detail: "Invalid protocol version: client 1.3.0, server not-semver"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/packages/sdk-go/runtime_compatibility_test.go
+++ b/packages/sdk-go/runtime_compatibility_test.go
@@ -112,7 +112,7 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			}`, stagehandProtocolVersion),
 			kind:   runtimeIncompatible,
 			reason: "runtime-name-mismatch",
-			detail: `Connected runtime is not Stagehand: serverInfo.name="other"`,
+			detail: `Runtime name mismatch: expected "stagehand", server reported "other"`,
 		},
 		{
 			name: "invalid protocol version",
@@ -122,6 +122,15 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			}`,
 			kind:   runtimeUnknown,
 			detail: "protocolVersion=1",
+		},
+		{
+			name: "empty protocol version",
+			marker: `{
+				"protocolVersion": "",
+				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
+			}`,
+			kind:   runtimeUnknown,
+			detail: "protocolVersion=",
 		},
 		{
 			name: "non-semver protocol version",

--- a/packages/sdk-go/runtime_compatibility_test.go
+++ b/packages/sdk-go/runtime_compatibility_test.go
@@ -18,10 +18,11 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 	incompatibleProtocolVersion := fmt.Sprintf("%d.0.0", protocolMajor+1)
 
 	tests := []struct {
-		name       string
-		marker     string
-		compatible bool
-		detail     string
+		name   string
+		marker string
+		kind   runtimeCompatibilityKind
+		reason string
+		detail string
 	}{
 		{
 			name: "compatible",
@@ -29,14 +30,20 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 				"protocolVersion": %q,
 				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
 			}`, stagehandProtocolVersion),
-			compatible: true,
-			detail:     "protocolVersion=" + stagehandProtocolVersion,
+			kind:   runtimeCompatible,
+			detail: "protocolVersion=" + stagehandProtocolVersion,
 		},
 		{
-			name:       "missing marker",
-			marker:     `null`,
-			compatible: false,
-			detail:     "no Stagehand runtime marker",
+			name:   "missing marker",
+			marker: `null`,
+			kind:   runtimeUnknown,
+			detail: "no Stagehand runtime marker",
+		},
+		{
+			name:   "empty marker",
+			marker: `{}`,
+			kind:   runtimeUnknown,
+			detail: "serverInfo.name=",
 		},
 		{
 			name: "major mismatch",
@@ -44,8 +51,9 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 				"protocolVersion": %q,
 				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
 			}`, incompatibleProtocolVersion),
-			compatible: false,
-			detail:     "major mismatch",
+			kind:   runtimeIncompatible,
+			reason: "protocol-major-mismatch",
+			detail: "major mismatch",
 		},
 		{
 			name: "wrong runtime",
@@ -53,8 +61,9 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 				"protocolVersion": %q,
 				"serverInfo": {"name": "other", "version": "1.0.0"}
 			}`, stagehandProtocolVersion),
-			compatible: false,
-			detail:     `serverInfo.name="other"`,
+			kind:   runtimeIncompatible,
+			reason: "runtime-name-mismatch",
+			detail: `serverInfo.name="other"`,
 		},
 		{
 			name: "invalid protocol version",
@@ -62,8 +71,18 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 				"protocolVersion": 1,
 				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
 			}`,
-			compatible: false,
-			detail:     "protocolVersion=1",
+			kind:   runtimeUnknown,
+			detail: "protocolVersion=1",
+		},
+		{
+			name: "non-semver protocol version",
+			marker: `{
+				"protocolVersion": "not-semver",
+				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
+			}`,
+			kind:   runtimeIncompatible,
+			reason: "protocol-invalid-version",
+			detail: "invalid protocol version",
 		},
 	}
 
@@ -71,14 +90,20 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			compatible, detail := negotiateRuntimeCompatibility(
+			negotiation := negotiateRuntimeCompatibility(
 				json.RawMessage(test.marker),
 			)
-			if compatible != test.compatible {
-				t.Fatalf("compatible = %t, want %t", compatible, test.compatible)
+			if negotiation.kind != test.kind {
+				t.Fatalf("kind = %q, want %q", negotiation.kind, test.kind)
 			}
-			if !strings.Contains(detail, test.detail) {
-				t.Fatalf("detail = %q, want it to contain %q", detail, test.detail)
+			if negotiation.reason != test.reason {
+				t.Fatalf("reason = %q, want %q", negotiation.reason, test.reason)
+			}
+			if !strings.Contains(negotiation.detail, test.detail) {
+				t.Fatalf("detail = %q, want it to contain %q", negotiation.detail, test.detail)
+			}
+			if negotiation.compatible() != (test.kind == runtimeCompatible) {
+				t.Fatalf("compatible() = %t for kind %q", negotiation.compatible(), negotiation.kind)
 			}
 		})
 	}
@@ -92,22 +117,26 @@ func TestProtocolCompatibility(t *testing.T) {
 		client     string
 		server     string
 		compatible bool
+		reason     string
 		detail     string
 	}{
 		{name: "patch ignored", client: "1.2.4", server: "1.2.0", compatible: true},
 		{name: "newer server minor", client: "1.2.4", server: "1.9.0", compatible: true},
-		{name: "server too old", client: "1.2.4", server: "1.1.99", detail: "older"},
-		{name: "major mismatch", client: "1.2.4", server: "2.0.0", detail: "major mismatch"},
+		{name: "server too old", client: "1.2.4", server: "1.1.99", reason: "protocol-server-too-old", detail: "older"},
+		{name: "major mismatch", client: "1.2.4", server: "2.0.0", reason: "protocol-major-mismatch", detail: "major mismatch"},
 		{name: "exact prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.1", compatible: true},
-		{name: "different prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.2", detail: "match exactly"},
-		{name: "invalid client", client: "not-semver", server: "1.3.0", detail: "invalid protocol version"},
-		{name: "invalid server", client: "1.3.0", server: "not-semver", detail: "invalid protocol version"},
+		{name: "different prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.2", reason: "protocol-prerelease-mismatch", detail: "match exactly"},
+		{name: "invalid client", client: "not-semver", server: "1.3.0", reason: "protocol-invalid-version", detail: "invalid protocol version"},
+		{name: "invalid server", client: "1.3.0", server: "not-semver", reason: "protocol-invalid-version", detail: "invalid protocol version"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			compatible, detail := protocolCompatibility(test.client, test.server)
+			compatible, reason, detail := protocolCompatibility(test.client, test.server)
 			if compatible != test.compatible {
 				t.Fatalf("compatible = %t, want %t", compatible, test.compatible)
+			}
+			if reason != test.reason {
+				t.Fatalf("reason = %q, want %q", reason, test.reason)
 			}
 			if !strings.Contains(detail, test.detail) {
 				t.Fatalf("detail = %q, want it to contain %q", detail, test.detail)

--- a/packages/sdk-python/src/stagehand/__init__.py
+++ b/packages/sdk-python/src/stagehand/__init__.py
@@ -58,6 +58,7 @@ from ._generated.models import (
 from .browser import StagehandBrowser, browserbase, local_browser
 from .browser_clipboard import BrowserClipboard
 from .browser_context import BrowserContext
+from .cdp_client import StagehandRuntimeIncompatibleError
 from .client_models import (
     BrowserbaseFetchResult,
     BrowserbaseSearchResult,
@@ -147,6 +148,7 @@ __all__ = [
     "StagehandClientLoggingConfig",
     "StagehandMetrics",
     "StagehandResultMetadata",
+    "StagehandRuntimeIncompatibleError",
     "State",
     "TelemetryConfig",
     "Variables",

--- a/packages/sdk-python/src/stagehand/cdp_client.py
+++ b/packages/sdk-python/src/stagehand/cdp_client.py
@@ -120,8 +120,12 @@ def _negotiate_runtime(marker: object) -> _RuntimeNegotiation:
         return _RuntimeNegotiation("unknown", f"serverInfo={server_info!r}")
     name = server_info.get("name")
     version = server_info.get("version")
-    if not isinstance(name, str) or not isinstance(version, str):
-        return _RuntimeNegotiation("unknown", f"serverInfo.name={name!r}")
+    # Mirrors the protocol's ImplementationInfoSchema: both fields are non-empty strings.
+    # A marker missing either is malformed, not a foreign runtime, so keep polling.
+    if not isinstance(name, str) or not name or not isinstance(version, str) or not version:
+        return _RuntimeNegotiation(
+            "unknown", f"serverInfo.name={name!r} serverInfo.version={version!r}"
+        )
 
     protocol_version = marker.get("protocolVersion")
     if not isinstance(protocol_version, str):
@@ -130,7 +134,7 @@ def _negotiate_runtime(marker: object) -> _RuntimeNegotiation:
     if name != _RUNTIME_NAME:
         return _RuntimeNegotiation(
             "incompatible",
-            f"connected runtime is not Stagehand: serverInfo.name={name!r}",
+            f"Connected runtime is not Stagehand: serverInfo.name={json.dumps(name)}",
             reason="runtime-name-mismatch",
             protocol_version=protocol_version,
             server_name=name,
@@ -165,25 +169,25 @@ def _protocol_compatibility(client_version: str, server_version: str) -> tuple[s
     if client is None or server is None:
         return (
             "protocol-invalid-version",
-            f"invalid protocol version: client={client_version!r} server={server_version!r}",
+            f"Invalid protocol version: client {client_version}, server {server_version}",
         )
     if client.group(4) is not None or server.group(4) is not None:
         if client_version != server_version:
             return (
                 "protocol-prerelease-mismatch",
-                "protocol prereleases must match exactly: "
-                f"client={client_version} server={server_version}",
+                "Protocol prereleases must match exactly: "
+                f"client {client_version}, server {server_version}",
             )
         return None
     if client.group(1) != server.group(1):
         return (
             "protocol-major-mismatch",
-            f"protocol major mismatch: client={client_version} server={server_version}",
+            f"Protocol major mismatch: client {client_version}, server {server_version}",
         )
     if int(server.group(2)) < int(client.group(2)):
         return (
             "protocol-server-too-old",
-            f"server protocol {server_version} is older than client requirement {client_version}",
+            f"Server protocol {server_version} is older than client requirement {client_version}",
         )
     return None
 

--- a/packages/sdk-python/src/stagehand/cdp_client.py
+++ b/packages/sdk-python/src/stagehand/cdp_client.py
@@ -128,13 +128,13 @@ def _negotiate_runtime(marker: object) -> _RuntimeNegotiation:
         )
 
     protocol_version = marker.get("protocolVersion")
-    if not isinstance(protocol_version, str):
+    if not isinstance(protocol_version, str) or not protocol_version:
         return _RuntimeNegotiation("unknown", f"protocolVersion={protocol_version!r}")
 
     if name != _RUNTIME_NAME:
         return _RuntimeNegotiation(
             "incompatible",
-            f"Connected runtime is not Stagehand: serverInfo.name={json.dumps(name)}",
+            f'Runtime name mismatch: expected "{_RUNTIME_NAME}", server reported "{name}"',
             reason="runtime-name-mismatch",
             protocol_version=protocol_version,
             server_name=name,

--- a/packages/sdk-python/src/stagehand/cdp_client.py
+++ b/packages/sdk-python/src/stagehand/cdp_client.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 from urllib.request import urlopen
 
 from stagehand._generated.protocol_version import (
@@ -59,42 +59,132 @@ def _callback_source_from_message(message: dict[str, object]) -> str | None:
     return source
 
 
-def _negotiate_runtime(marker: object) -> tuple[bool, str]:
-    """Return (compatible, detail). Never raises: a malformed marker is just incompatible."""
+RUNTIME_INCOMPATIBLE_REMEDIATION = (
+    "Upgrade the Stagehand SDK and the Stagehand extension together so their protocol majors "
+    "match, or start the session with the extension bundled in this SDK."
+)
+
+
+@dataclass(frozen=True)
+class _RuntimeNegotiation:
+    """Outcome of reading the runtime marker the extension publishes.
+
+    ``kind`` is three-way on purpose: ``"unknown"`` means the marker is absent or not yet
+    readable and the caller should keep polling, while ``"incompatible"`` means the marker
+    parsed but this client can never talk to that runtime, so polling is pointless.
+    """
+
+    kind: Literal["compatible", "incompatible", "unknown"]
+    detail: str
+    reason: str | None = None
+    protocol_version: str | None = None
+    server_name: str | None = None
+    server_version: str | None = None
+
+    @property
+    def compatible(self) -> bool:
+        return self.kind == "compatible"
+
+
+class StagehandRuntimeIncompatibleError(RuntimeError):
+    """The connected Stagehand extension speaks a protocol this SDK cannot use.
+
+    Raised on the first readiness poll that observes the incompatible marker; initialization
+    does not wait for the timeout because the extension will not change its protocol version
+    while the session is open.
+    """
+
+    def __init__(self, negotiation: _RuntimeNegotiation) -> None:
+        self.reason = negotiation.reason or "protocol-incompatible"
+        self.client_protocol_version = STAGEHAND_PROTOCOL_VERSION
+        self.reported_protocol_version = negotiation.protocol_version
+        self.server_name = negotiation.server_name
+        self.server_version = negotiation.server_version
+        self.remediation = RUNTIME_INCOMPATIBLE_REMEDIATION
+        super().__init__(
+            f"Incompatible Stagehand runtime: {negotiation.detail}; "
+            f"client protocol {self.client_protocol_version}, "
+            f"reported protocol {self.reported_protocol_version}, "
+            f"server {self.server_name}/{self.server_version}. "
+            f"{self.remediation}"
+        )
+
+
+def _negotiate_runtime(marker: object) -> _RuntimeNegotiation:
+    """Classify the runtime marker. Never raises: hostile input is just ``unknown``."""
     if not isinstance(marker, Mapping):
-        return False, "no Stagehand runtime marker"
+        return _RuntimeNegotiation("unknown", "no Stagehand runtime marker")
 
     server_info = marker.get("serverInfo")
-    name = server_info.get("name") if isinstance(server_info, Mapping) else None
-    if name != _RUNTIME_NAME:
-        return False, f"serverInfo.name={name!r}"
+    if not isinstance(server_info, Mapping):
+        return _RuntimeNegotiation("unknown", f"serverInfo={server_info!r}")
+    name = server_info.get("name")
+    version = server_info.get("version")
+    if not isinstance(name, str) or not isinstance(version, str):
+        return _RuntimeNegotiation("unknown", f"serverInfo.name={name!r}")
 
     protocol_version = marker.get("protocolVersion")
     if not isinstance(protocol_version, str):
-        return False, f"protocolVersion={protocol_version!r}"
-    compatibility = _protocol_compatibility(STAGEHAND_PROTOCOL_VERSION, protocol_version)
-    if compatibility is not None:
-        return False, compatibility
+        return _RuntimeNegotiation("unknown", f"protocolVersion={protocol_version!r}")
 
-    return True, f"protocolVersion={protocol_version}"
+    if name != _RUNTIME_NAME:
+        return _RuntimeNegotiation(
+            "incompatible",
+            f"connected runtime is not Stagehand: serverInfo.name={name!r}",
+            reason="runtime-name-mismatch",
+            protocol_version=protocol_version,
+            server_name=name,
+            server_version=version,
+        )
+
+    incompatibility = _protocol_compatibility(STAGEHAND_PROTOCOL_VERSION, protocol_version)
+    if incompatibility is not None:
+        reason, detail = incompatibility
+        return _RuntimeNegotiation(
+            "incompatible",
+            detail,
+            reason=reason,
+            protocol_version=protocol_version,
+            server_name=name,
+            server_version=version,
+        )
+
+    return _RuntimeNegotiation(
+        "compatible",
+        f"protocolVersion={protocol_version}",
+        protocol_version=protocol_version,
+        server_name=name,
+        server_version=version,
+    )
 
 
-def _protocol_compatibility(client_version: str, server_version: str) -> str | None:
+def _protocol_compatibility(client_version: str, server_version: str) -> tuple[str, str] | None:
+    """Return ``None`` when compatible, otherwise ``(reason, detail)``."""
     client = _PROTOCOL_SEMVER_PATTERN.fullmatch(client_version)
     server = _PROTOCOL_SEMVER_PATTERN.fullmatch(server_version)
     if client is None or server is None:
-        return f"invalid protocol version: client={client_version!r} server={server_version!r}"
+        return (
+            "protocol-invalid-version",
+            f"invalid protocol version: client={client_version!r} server={server_version!r}",
+        )
     if client.group(4) is not None or server.group(4) is not None:
         if client_version != server_version:
             return (
+                "protocol-prerelease-mismatch",
                 "protocol prereleases must match exactly: "
-                f"client={client_version} server={server_version}"
+                f"client={client_version} server={server_version}",
             )
         return None
     if client.group(1) != server.group(1):
-        return f"protocol major mismatch: client={client_version} server={server_version}"
+        return (
+            "protocol-major-mismatch",
+            f"protocol major mismatch: client={client_version} server={server_version}",
+        )
     if int(server.group(2)) < int(client.group(2)):
-        return f"server protocol {server_version} is older than client requirement {client_version}"
+        return (
+            "protocol-server-too-old",
+            f"server protocol {server_version} is older than client requirement {client_version}",
+        )
     return None
 
 
@@ -474,7 +564,17 @@ class CDPClient:
                     "Target.closeTarget", {"targetId": activation_target_id}
                 )
 
-    async def _wait_for_runtime_receiver(self, session_id: str) -> None:
+    async def _wait_for_runtime_receiver(
+        self,
+        session_id: str,
+        *,
+        allow_fallback_install: bool = False,
+    ) -> None:
+        """Poll until the extension runtime is ready.
+
+        ``allow_fallback_install`` is reserved for flows that can replace an incompatible
+        preloaded extension; by default an incompatible marker fails on the first poll.
+        """
         while True:
             try:
                 evaluated = await self.send_command(
@@ -485,17 +585,20 @@ class CDPClient:
                     },
                     session_id=session_id,
                 )
+            except Exception:
+                evaluated = None
+            if evaluated is not None:
                 exception = evaluated.get("exceptionDetails")
                 if not isinstance(exception, Mapping):
                     result = evaluated.get("result")
                     value = result.get("value") if isinstance(result, Mapping) else None
                     if isinstance(value, Mapping):
                         has_receiver = value.get("hasReceiver") is True
-                        compatible, _ = _negotiate_runtime(value.get("marker"))
-                        if compatible and has_receiver:
+                        negotiation = _negotiate_runtime(value.get("marker"))
+                        if negotiation.kind == "incompatible" and not allow_fallback_install:
+                            raise StagehandRuntimeIncompatibleError(negotiation)
+                        if negotiation.compatible and has_receiver:
                             return
-            except Exception:
-                pass
             await asyncio.sleep(0.1)
 
     def _schedule_best_effort_command(self, method: str, params: Mapping[str, object]) -> None:

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -12,6 +12,7 @@ from stagehand.cdp_client import (
     STAGEHAND_SEND_TO_HOST_BINDING,
     CDPClient,
     ServiceWorkerInfo,
+    StagehandRuntimeIncompatibleError,
 )
 
 
@@ -601,6 +602,16 @@ async def test_installed_extension_discovery_propagates_cdp_command_errors() -> 
     assert [message["method"] for message in socket.sent] == ["Extensions.getExtensions"]
 
 
+_INCOMPATIBLE_PROTOCOL_VERSION = f"{int(STAGEHAND_PROTOCOL_VERSION.split('.')[0]) + 1}.0.0"
+
+
+def _marker(protocol_version: str, *, name: str = "stagehand") -> dict[str, object]:
+    return {
+        "protocolVersion": protocol_version,
+        "serverInfo": {"name": name, "version": "1.0.0"},
+    }
+
+
 class TestNegotiateRuntime:
     """Mirrors the TypeScript negotiation tests so the two SDKs cannot drift apart.
 
@@ -610,72 +621,165 @@ class TestNegotiateRuntime:
     """
 
     def test_accepts_a_current_marker(self) -> None:
-        compatible, detail = cdp_client._negotiate_runtime({
-            "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
-            "serverInfo": {"name": "stagehand", "version": "1.0.0"},
-        })
-        assert compatible is True
-        assert f"protocolVersion={STAGEHAND_PROTOCOL_VERSION}" in detail
+        negotiation = cdp_client._negotiate_runtime(_marker(STAGEHAND_PROTOCOL_VERSION))
+        assert negotiation.kind == "compatible"
+        assert negotiation.compatible is True
+        assert f"protocolVersion={STAGEHAND_PROTOCOL_VERSION}" in negotiation.detail
 
     def test_tolerates_unknown_extra_keys(self) -> None:
         # A newer runtime may publish fields this client has never heard of, e.g. `status`.
-        compatible, _ = cdp_client._negotiate_runtime({
-            "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
-            "serverInfo": {"name": "stagehand", "version": "1.0.0"},
+        negotiation = cdp_client._negotiate_runtime({
+            **_marker(STAGEHAND_PROTOCOL_VERSION),
             "status": {"state": "ready"},
         })
-        assert compatible is True
+        assert negotiation.kind == "compatible"
 
     @pytest.mark.parametrize(
         ("marker", "expected"),
         [
             (None, "no Stagehand runtime marker"),
-            ({}, "serverInfo.name=None"),
+            ({}, "serverInfo=None"),
+            ({"serverInfo": "not-a-mapping"}, "serverInfo="),
+            ({"serverInfo": {"version": "1"}}, "serverInfo.name=None"),
             (
-                {
-                    "protocolVersion": f"{int(STAGEHAND_PROTOCOL_VERSION.split('.')[0]) + 1}.0.0",
-                    "serverInfo": {"name": "stagehand", "version": "0"},
-                },
-                "major mismatch",
-            ),
-            (
-                {
-                    "protocolVersion": "not-semver",
-                    "serverInfo": {"name": "stagehand", "version": "2"},
-                },
-                "invalid protocol version",
-            ),
-            (
-                {
-                    "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
-                    "serverInfo": {"name": "other", "version": "1"},
-                },
-                "name=",
-            ),
-            (
-                {
-                    "protocolVersion": 1,
-                    "serverInfo": {"name": "stagehand", "version": "1"},
-                },
+                {"protocolVersion": 1, "serverInfo": {"name": "stagehand", "version": "1"}},
                 "protocolVersion=1",
             ),
         ],
     )
-    def test_rejects_unusable_markers(self, marker: object, expected: str) -> None:
-        compatible, detail = cdp_client._negotiate_runtime(marker)
-        assert compatible is False
-        assert expected in detail
+    def test_reports_unreadable_markers_as_unknown(self, marker: object, expected: str) -> None:
+        negotiation = cdp_client._negotiate_runtime(marker)
+        assert negotiation.kind == "unknown"
+        assert negotiation.compatible is False
+        assert negotiation.reason is None
+        assert expected in negotiation.detail
+
+    @pytest.mark.parametrize(
+        ("marker", "reason", "expected"),
+        [
+            (
+                _marker(_INCOMPATIBLE_PROTOCOL_VERSION),
+                "protocol-major-mismatch",
+                "major mismatch",
+            ),
+            (
+                _marker("not-semver"),
+                "protocol-invalid-version",
+                "invalid protocol version",
+            ),
+            (
+                _marker(STAGEHAND_PROTOCOL_VERSION, name="other"),
+                "runtime-name-mismatch",
+                "serverInfo.name='other'",
+            ),
+        ],
+    )
+    def test_reports_unusable_runtimes_as_incompatible(
+        self, marker: dict[str, object], reason: str, expected: str
+    ) -> None:
+        negotiation = cdp_client._negotiate_runtime(marker)
+        assert negotiation.kind == "incompatible"
+        assert negotiation.compatible is False
+        assert negotiation.reason == reason
+        assert expected in negotiation.detail
+        assert negotiation.protocol_version == marker["protocolVersion"]
+        assert negotiation.server_version == "1.0.0"
 
     def test_never_raises_on_hostile_input(self) -> None:
         for marker in ("string", 42, [], {"serverInfo": "not-a-mapping"}, {"serverInfo": None}):
-            assert cdp_client._negotiate_runtime(marker)[0] is False
+            assert cdp_client._negotiate_runtime(marker).kind == "unknown"
 
     def test_protocol_semver_directionality(self) -> None:
-        assert cdp_client._protocol_compatibility("1.2.4", "1.2.0") is None
-        assert cdp_client._protocol_compatibility("1.2.4", "1.9.0") is None
-        assert "older" in (cdp_client._protocol_compatibility("1.2.4", "1.1.99") or "")
-        assert "major mismatch" in (cdp_client._protocol_compatibility("1.2.4", "2.0.0") or "")
-        assert cdp_client._protocol_compatibility("1.3.0-beta.1", "1.3.0-beta.1") is None
-        assert "match exactly" in (
-            cdp_client._protocol_compatibility("1.3.0-beta.1", "1.3.0-beta.2") or ""
-        )
+        def reason(client: str, server: str) -> str | None:
+            result = cdp_client._protocol_compatibility(client, server)
+            return None if result is None else result[0]
+
+        assert reason("1.2.4", "1.2.0") is None
+        assert reason("1.2.4", "1.9.0") is None
+        assert reason("1.2.4", "1.1.99") == "protocol-server-too-old"
+        assert reason("1.2.4", "2.0.0") == "protocol-major-mismatch"
+        assert reason("1.3.0-beta.1", "1.3.0-beta.1") is None
+        assert reason("1.3.0-beta.1", "1.3.0-beta.2") == "protocol-prerelease-mismatch"
+        assert reason("not-semver", "1.3.0") == "protocol-invalid-version"
+
+
+def _readiness_client(
+    responses: list[dict[str, object]],
+) -> tuple[CDPClient, FakeWebSocket]:
+    """A client whose Runtime.evaluate answers are consumed in order (last one repeats)."""
+
+    def response_for(_: dict[str, object]) -> dict[str, object]:
+        envelope = responses.pop(0) if len(responses) > 1 else responses[0]
+        return {"result": envelope}
+
+    socket = FakeWebSocket(response_for)
+    return CDPClient(socket, "ws://127.0.0.1/devtools/browser/test"), socket
+
+
+def _readiness(marker: object, *, has_receiver: bool = True) -> dict[str, object]:
+    return {"result": {"value": {"marker": marker, "hasReceiver": has_receiver}}}
+
+
+async def test_runtime_wait_fails_fast_on_an_incompatible_marker() -> None:
+    client, socket = _readiness_client([_readiness(_marker(_INCOMPATIBLE_PROTOCOL_VERSION))])
+    try:
+        with pytest.raises(StagehandRuntimeIncompatibleError) as raised:
+            await asyncio.wait_for(client._wait_for_runtime_receiver("worker-session"), timeout=1)
+    finally:
+        await client.close()
+
+    error = raised.value
+    assert error.reason == "protocol-major-mismatch"
+    assert error.client_protocol_version == STAGEHAND_PROTOCOL_VERSION
+    assert error.reported_protocol_version == _INCOMPATIBLE_PROTOCOL_VERSION
+    assert (error.server_name, error.server_version) == ("stagehand", "1.0.0")
+    assert f"client protocol {STAGEHAND_PROTOCOL_VERSION}" in str(error)
+    assert f"reported protocol {_INCOMPATIBLE_PROTOCOL_VERSION}" in str(error)
+    assert "Upgrade the Stagehand SDK and the Stagehand extension" in str(error)
+    # Raised on the first poll: exactly one readiness evaluation, no sleep/re-poll.
+    assert [message["method"] for message in socket.sent] == ["Runtime.evaluate"]
+
+
+async def test_runtime_wait_fails_fast_on_a_foreign_runtime() -> None:
+    client, socket = _readiness_client([
+        _readiness(_marker(STAGEHAND_PROTOCOL_VERSION, name="other"))
+    ])
+    try:
+        with pytest.raises(StagehandRuntimeIncompatibleError) as raised:
+            await asyncio.wait_for(client._wait_for_runtime_receiver("worker-session"), timeout=1)
+    finally:
+        await client.close()
+
+    assert raised.value.reason == "runtime-name-mismatch"
+    assert raised.value.server_name == "other"
+    assert [message["method"] for message in socket.sent] == ["Runtime.evaluate"]
+
+
+async def test_runtime_wait_keeps_polling_an_unknown_marker_until_compatible() -> None:
+    client, socket = _readiness_client([
+        _readiness(None, has_receiver=False),
+        _readiness(None, has_receiver=False),
+        _readiness(None, has_receiver=True),
+        {"result": {"value": _ready_marker()}},
+    ])
+    try:
+        await asyncio.wait_for(client._wait_for_runtime_receiver("worker-session"), timeout=5)
+    finally:
+        await client.close()
+
+    assert [message["method"] for message in socket.sent] == ["Runtime.evaluate"] * 4
+
+
+async def test_runtime_wait_keeps_polling_an_incompatible_marker_when_fallback_is_allowed() -> None:
+    client, socket = _readiness_client([_readiness(_marker(_INCOMPATIBLE_PROTOCOL_VERSION))])
+    try:
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(
+                client._wait_for_runtime_receiver("worker-session", allow_fallback_install=True),
+                timeout=0.35,
+            )
+    finally:
+        await client.close()
+
+    assert len(socket.sent) >= 2
+    assert {message["method"] for message in socket.sent} == {"Runtime.evaluate"}

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -641,6 +641,10 @@ class TestNegotiateRuntime:
             ({}, "serverInfo=None"),
             ({"serverInfo": "not-a-mapping"}, "serverInfo="),
             ({"serverInfo": {"version": "1"}}, "serverInfo.name=None"),
+            ({"serverInfo": {"name": "stagehand"}}, "serverInfo.version=None"),
+            ({"serverInfo": {"name": "", "version": "1"}}, "serverInfo.name=''"),
+            ({"serverInfo": {"name": "stagehand", "version": ""}}, "serverInfo.version=''"),
+            ({"serverInfo": {"name": 1, "version": "1"}}, "serverInfo.name=1"),
             (
                 {"protocolVersion": 1, "serverInfo": {"name": "stagehand", "version": "1"}},
                 "protocolVersion=1",
@@ -660,17 +664,18 @@ class TestNegotiateRuntime:
             (
                 _marker(_INCOMPATIBLE_PROTOCOL_VERSION),
                 "protocol-major-mismatch",
-                "major mismatch",
+                f"Protocol major mismatch: client {STAGEHAND_PROTOCOL_VERSION}, "
+                f"server {_INCOMPATIBLE_PROTOCOL_VERSION}",
             ),
             (
                 _marker("not-semver"),
                 "protocol-invalid-version",
-                "invalid protocol version",
+                f"Invalid protocol version: client {STAGEHAND_PROTOCOL_VERSION}, server not-semver",
             ),
             (
                 _marker(STAGEHAND_PROTOCOL_VERSION, name="other"),
                 "runtime-name-mismatch",
-                "serverInfo.name='other'",
+                'Connected runtime is not Stagehand: serverInfo.name="other"',
             ),
         ],
     )
@@ -701,6 +706,28 @@ class TestNegotiateRuntime:
         assert reason("1.3.0-beta.1", "1.3.0-beta.1") is None
         assert reason("1.3.0-beta.1", "1.3.0-beta.2") == "protocol-prerelease-mismatch"
         assert reason("not-semver", "1.3.0") == "protocol-invalid-version"
+        assert reason("1.3.0", "not-semver") == "protocol-invalid-version"
+
+    @pytest.mark.parametrize(
+        ("client", "server", "detail"),
+        [
+            ("1.2.4", "1.1.99", "Server protocol 1.1.99 is older than client requirement 1.2.4"),
+            ("1.2.4", "2.0.0", "Protocol major mismatch: client 1.2.4, server 2.0.0"),
+            (
+                "1.3.0-beta.1",
+                "1.3.0-beta.2",
+                "Protocol prereleases must match exactly: client 1.3.0-beta.1, server 1.3.0-beta.2",
+            ),
+            ("1.3.0", "not-semver", "Invalid protocol version: client 1.3.0, server not-semver"),
+        ],
+    )
+    def test_protocol_detail_wording_matches_typescript(
+        self, client: str, server: str, detail: str
+    ) -> None:
+        # The TS SDK's compatibilityDetail is the reference wording; keep the SDKs identical.
+        result = cdp_client._protocol_compatibility(client, server)
+        assert result is not None
+        assert result[1] == detail
 
 
 def _readiness_client(

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -649,6 +649,10 @@ class TestNegotiateRuntime:
                 {"protocolVersion": 1, "serverInfo": {"name": "stagehand", "version": "1"}},
                 "protocolVersion=1",
             ),
+            (
+                {"protocolVersion": "", "serverInfo": {"name": "stagehand", "version": "1"}},
+                "protocolVersion=''",
+            ),
         ],
     )
     def test_reports_unreadable_markers_as_unknown(self, marker: object, expected: str) -> None:
@@ -675,7 +679,7 @@ class TestNegotiateRuntime:
             (
                 _marker(STAGEHAND_PROTOCOL_VERSION, name="other"),
                 "runtime-name-mismatch",
-                'Connected runtime is not Stagehand: serverInfo.name="other"',
+                'Runtime name mismatch: expected "stagehand", server reported "other"',
             ),
         ],
     )

--- a/packages/sdk-ts/src/cdpClient.ts
+++ b/packages/sdk-ts/src/cdpClient.ts
@@ -5,10 +5,12 @@ import {
   StagehandSendToHostBindingSchema,
 } from "@browserbasehq/stagehand-protocol/schema-registry";
 import { z } from "zod/v4";
+import type { ImplementationInfo } from "@browserbasehq/stagehand-protocol/types";
 import {
   DEFAULT_RUNTIME_REQUIREMENT,
   negotiateRuntimeCompatibility,
   type RuntimeCompatibility,
+  type RuntimeIncompatibilityReason,
   type RuntimeRequirement,
 } from "./runtimeCompatibility.js";
 import { abortable, abortableDelay, abortReason, throwIfAborted } from "./abort.js";
@@ -104,8 +106,25 @@ export function stagehandMessageExpression(message: JSONRPCMessage): string {
     : `void globalThis.__stagehandReceiveFromHost(${JSON.stringify(JSON.stringify(message))}); true`;
 }
 
+export const RUNTIME_INCOMPATIBLE_REMEDIATION =
+  "Upgrade the Stagehand SDK and the Stagehand extension together so their protocol majors match, " +
+  "or start the session with the extension bundled in this SDK.";
+
+/**
+ * Raised as soon as the connected Stagehand extension publishes a runtime marker this SDK cannot
+ * talk to. Initialization does not keep polling: the extension will not change its protocol
+ * version while the session is open.
+ */
 export class StagehandRuntimeIncompatibleError extends Error {
-  readonly reason;
+  readonly reason: RuntimeIncompatibilityReason;
+  /** Protocol version this SDK speaks. */
+  readonly clientProtocolVersion: string;
+  /** Protocol version the connected extension reported. */
+  readonly reportedProtocolVersion: string;
+  /** `serverInfo` published by the connected runtime (name + version). */
+  readonly serverInfo: ImplementationInfo;
+  readonly remediation = RUNTIME_INCOMPATIBLE_REMEDIATION;
+
   constructor(readonly compatibility: Extract<RuntimeCompatibility, { kind: "incompatible" }>) {
     super(
       "Incompatible Stagehand runtime: " +
@@ -117,10 +136,15 @@ export class StagehandRuntimeIncompatibleError extends Error {
         ", server " +
         compatibility.reported.serverInfo.name +
         "/" +
-        compatibility.reported.serverInfo.version,
+        compatibility.reported.serverInfo.version +
+        ". " +
+        RUNTIME_INCOMPATIBLE_REMEDIATION,
     );
     this.name = "StagehandRuntimeIncompatibleError";
     this.reason = compatibility.reason;
+    this.clientProtocolVersion = compatibility.required.protocolVersion;
+    this.reportedProtocolVersion = compatibility.reported.protocolVersion;
+    this.serverInfo = { ...compatibility.reported.serverInfo };
   }
 }
 
@@ -484,6 +508,11 @@ export async function waitForRuntimeReady(
     pollIntervalMs?: number;
     delayFn?: (ms: number) => Promise<void>;
     runtimeRequirement?: RuntimeRequirement;
+    /**
+     * Reserved for flows that can replace an incompatible preloaded extension. When not explicitly
+     * `true`, an incompatible marker fails initialization on the first poll instead of polling
+     * until the initialization timeout.
+     */
     allowFallbackInstall?: boolean;
     signal: AbortSignal;
   },
@@ -502,7 +531,7 @@ export async function waitForRuntimeReady(
         options.runtimeRequirement ?? DEFAULT_RUNTIME_REQUIREMENT,
         readiness.marker,
       );
-      if (compatibility.kind === "incompatible" && options.allowFallbackInstall === false)
+      if (compatibility.kind === "incompatible" && options.allowFallbackInstall !== true)
         throw new StagehandRuntimeIncompatibleError(compatibility);
       if (compatibility.kind === "compatible" && readiness.hasReceiver) return;
     }

--- a/packages/sdk-ts/src/cdpClient.ts
+++ b/packages/sdk-ts/src/cdpClient.ts
@@ -117,6 +117,8 @@ export const RUNTIME_INCOMPATIBLE_REMEDIATION =
  */
 export class StagehandRuntimeIncompatibleError extends Error {
   readonly reason: RuntimeIncompatibilityReason;
+  /** Human-readable negotiation failure, without the version summary or remediation. */
+  readonly detail: string;
   /** Protocol version this SDK speaks. */
   readonly clientProtocolVersion: string;
   /** Protocol version the connected extension reported. */
@@ -142,6 +144,7 @@ export class StagehandRuntimeIncompatibleError extends Error {
     );
     this.name = "StagehandRuntimeIncompatibleError";
     this.reason = compatibility.reason;
+    this.detail = compatibility.detail;
     this.clientProtocolVersion = compatibility.required.protocolVersion;
     this.reportedProtocolVersion = compatibility.reported.protocolVersion;
     this.serverInfo = { ...compatibility.reported.serverInfo };

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -40,6 +40,13 @@ export {
 export { WebMCPInvocation, WebMCPTool } from "./webmcp.js";
 export type { InitScriptSource } from "./pageScripts.js";
 export { Stagehand, type ExtractResult } from "./stagehand.js";
+export { StagehandRuntimeIncompatibleError } from "./cdpClient.js";
+export type {
+  ReportedRuntimeDescriptor,
+  RuntimeCompatibility,
+  RuntimeIncompatibilityReason,
+  RuntimeRequirement,
+} from "./runtimeCompatibility.js";
 export type {
   ExperimentalBatchCallback,
   ExperimentalBatchBrowserContext,

--- a/packages/sdk-ts/src/runtimeCompatibility.ts
+++ b/packages/sdk-ts/src/runtimeCompatibility.ts
@@ -3,10 +3,7 @@ import {
   ImplementationInfoSchema,
   STAGEHAND_PROTOCOL_VERSION,
 } from "@browserbasehq/stagehand-protocol/schemas";
-import {
-  checkProtocolCompatibility,
-  StagehandProtocolVersionSchema,
-} from "@browserbasehq/stagehand-protocol/protocol-version";
+import { checkProtocolCompatibility } from "@browserbasehq/stagehand-protocol/protocol-version";
 import { z } from "zod/v4";
 
 export const STAGEHAND_RUNTIME_NAME = "stagehand";
@@ -48,9 +45,11 @@ export type RuntimeCompatibility =
       detail: string;
     };
 
-// Accepts any server name so negotiation can distinguish a foreign runtime from garbage.
+// Accepts any server name so negotiation can distinguish a foreign runtime from garbage, and any
+// non-empty protocolVersion string so a non-SemVer version is reported as incompatible
+// (protocol-invalid-version) instead of being polled until the initialization timeout.
 const ReportedRuntimeDescriptorSchema = z.strictObject({
-  protocolVersion: StagehandProtocolVersionSchema,
+  protocolVersion: z.string().min(1),
   serverInfo: ImplementationInfoSchema,
 });
 

--- a/packages/sdk-ts/src/runtimeCompatibility.ts
+++ b/packages/sdk-ts/src/runtimeCompatibility.ts
@@ -1,17 +1,34 @@
-import type {
-  ImplementationInfo,
-  RuntimeDescriptor,
-} from "@browserbasehq/stagehand-protocol/types";
+import type { ImplementationInfo } from "@browserbasehq/stagehand-protocol/types";
 import {
-  RuntimeDescriptorSchema,
+  ImplementationInfoSchema,
   STAGEHAND_PROTOCOL_VERSION,
 } from "@browserbasehq/stagehand-protocol/schemas";
-import { checkProtocolCompatibility } from "@browserbasehq/stagehand-protocol/protocol-version";
+import {
+  checkProtocolCompatibility,
+  StagehandProtocolVersionSchema,
+} from "@browserbasehq/stagehand-protocol/protocol-version";
 import { z } from "zod/v4";
+
+export const STAGEHAND_RUNTIME_NAME = "stagehand";
 
 export type RuntimeRequirement = {
   protocolVersion: string;
 };
+/**
+ * The marker a connected runtime published. Unlike the protocol's `RuntimeDescriptor`, the
+ * server name is not pinned to "stagehand" so a foreign runtime can be reported as incompatible
+ * rather than silently treated as unreadable.
+ */
+export type ReportedRuntimeDescriptor = {
+  protocolVersion: string;
+  serverInfo: ImplementationInfo;
+};
+export type RuntimeIncompatibilityReason =
+  | "protocol-invalid-version"
+  | "protocol-major-mismatch"
+  | "protocol-server-too-old"
+  | "protocol-prerelease-mismatch"
+  | "runtime-name-mismatch";
 export type RuntimeCompatibility =
   | {
       kind: "compatible";
@@ -20,20 +37,22 @@ export type RuntimeCompatibility =
     }
   | {
       kind: "incompatible";
-      reason:
-        | "protocol-invalid-version"
-        | "protocol-major-mismatch"
-        | "protocol-server-too-old"
-        | "protocol-prerelease-mismatch";
+      reason: RuntimeIncompatibilityReason;
       detail: string;
       required: RuntimeRequirement;
-      reported: RuntimeDescriptor;
+      reported: ReportedRuntimeDescriptor;
     }
   | {
       kind: "unknown";
       reason: "missing-marker" | "unreadable-marker";
       detail: string;
     };
+
+// Accepts any server name so negotiation can distinguish a foreign runtime from garbage.
+const ReportedRuntimeDescriptorSchema = z.strictObject({
+  protocolVersion: StagehandProtocolVersionSchema,
+  serverInfo: ImplementationInfoSchema,
+});
 
 export const DEFAULT_RUNTIME_REQUIREMENT: RuntimeRequirement = Object.freeze({
   protocolVersion: STAGEHAND_PROTOCOL_VERSION,
@@ -51,7 +70,7 @@ export function negotiateRuntimeCompatibility(
     };
 
   try {
-    const result = RuntimeDescriptorSchema.safeParse(raw);
+    const result = ReportedRuntimeDescriptorSchema.safeParse(raw);
     if (!result.success)
       return {
         kind: "unknown",
@@ -60,6 +79,13 @@ export function negotiateRuntimeCompatibility(
       };
 
     const reported = descriptor(result.data);
+    if (reported.serverInfo.name !== STAGEHAND_RUNTIME_NAME)
+      return incompatible(
+        "runtime-name-mismatch",
+        `Connected runtime is not Stagehand: serverInfo.name=${JSON.stringify(reported.serverInfo.name)}`,
+        required,
+        reported,
+      );
     const compatibility = checkProtocolCompatibility(
       required.protocolVersion,
       reported.protocolVersion,
@@ -90,7 +116,7 @@ export function negotiateRuntimeCompatibility(
 }
 
 function compatibilityDetail(
-  reason: Extract<RuntimeCompatibility, { kind: "incompatible" }>["reason"],
+  reason: Exclude<RuntimeIncompatibilityReason, "runtime-name-mismatch">,
   clientVersion: string,
   serverVersion: string,
 ): string {
@@ -106,7 +132,7 @@ function compatibilityDetail(
   }
 }
 
-function descriptor(value: RuntimeDescriptor): RuntimeDescriptor {
+function descriptor(value: ReportedRuntimeDescriptor): ReportedRuntimeDescriptor {
   return {
     protocolVersion: value.protocolVersion,
     serverInfo: { ...value.serverInfo },
@@ -114,10 +140,10 @@ function descriptor(value: RuntimeDescriptor): RuntimeDescriptor {
 }
 
 function incompatible(
-  reason: Extract<RuntimeCompatibility, { kind: "incompatible" }>["reason"],
+  reason: RuntimeIncompatibilityReason,
   detail: string,
   required: RuntimeRequirement,
-  reported: RuntimeDescriptor,
+  reported: ReportedRuntimeDescriptor,
 ): RuntimeCompatibility {
   return {
     kind: "incompatible",

--- a/packages/sdk-ts/src/runtimeCompatibility.ts
+++ b/packages/sdk-ts/src/runtimeCompatibility.ts
@@ -81,7 +81,7 @@ export function negotiateRuntimeCompatibility(
     if (reported.serverInfo.name !== STAGEHAND_RUNTIME_NAME)
       return incompatible(
         "runtime-name-mismatch",
-        `Connected runtime is not Stagehand: serverInfo.name=${JSON.stringify(reported.serverInfo.name)}`,
+        `Runtime name mismatch: expected "${STAGEHAND_RUNTIME_NAME}", server reported "${reported.serverInfo.name}"`,
         required,
         reported,
       );

--- a/packages/sdk-ts/tests/cdpClientLifecycle.test.ts
+++ b/packages/sdk-ts/tests/cdpClientLifecycle.test.ts
@@ -322,32 +322,6 @@ describe("waitForRuntimeReady", () => {
     expect(cdp.calls.filter((call) => call.method === "Runtime.evaluate")).toHaveLength(2);
   });
 
-  it("keeps polling a non-Stagehand runtime until initialization is cancelled", async () => {
-    const controller = new AbortController();
-    const reason = new Error("initialization cancelled");
-    const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
-      result: {
-        value: {
-          marker: {
-            protocolVersion: STAGEHAND_PROTOCOL_VERSION,
-            serverInfo: { name: "other-extension", version: "1" },
-          },
-          hasReceiver: false,
-        },
-      },
-    }));
-
-    await expect(
-      waitForRuntimeReady(cdp, "worker-session", {
-        pollIntervalMs: 1,
-        signal: controller.signal,
-        delayFn: async () => {
-          controller.abort(reason);
-        },
-      }),
-    ).rejects.toBe(reason);
-  });
-
   it("keeps retrying when readiness evaluation throws", async () => {
     const results = [
       {
@@ -392,7 +366,87 @@ describe("waitForRuntimeReady", () => {
     expect(error).toBe(reason);
   });
 
-  it("keeps polling an out-of-range runtime by default until initialization is cancelled", async () => {
+  it("fails fast on the first poll that reports an incompatible runtime", async () => {
+    let delays = 0;
+    const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
+      result: { value: runtimeReadiness(incompatibleProtocolVersion) },
+    }));
+
+    const error = await rejectedError(
+      waitForRuntimeReady(cdp, "worker-session", {
+        pollIntervalMs: 1,
+        signal: lifecycleSignal,
+        delayFn: async () => {
+          delays += 1;
+        },
+      }),
+    );
+
+    expect(error).toBeInstanceOf(StagehandRuntimeIncompatibleError);
+    const incompatible = error as StagehandRuntimeIncompatibleError;
+    expect(incompatible.reason).toBe("protocol-major-mismatch");
+    expect(incompatible.clientProtocolVersion).toBe(STAGEHAND_PROTOCOL_VERSION);
+    expect(incompatible.reportedProtocolVersion).toBe(incompatibleProtocolVersion);
+    expect(incompatible.serverInfo).toStrictEqual({ name: "stagehand", version: "1.0.0" });
+    expect(incompatible.message).toContain(`client protocol ${STAGEHAND_PROTOCOL_VERSION}`);
+    expect(incompatible.message).toContain(`reported protocol ${incompatibleProtocolVersion}`);
+    expect(incompatible.message).toContain("Upgrade the Stagehand SDK and the Stagehand extension");
+    expect(cdp.calls.filter((call) => call.method === "Runtime.evaluate")).toHaveLength(1);
+    expect(delays).toBe(0);
+  });
+
+  it("fails fast when the runtime marker belongs to a different server", async () => {
+    let delays = 0;
+    const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
+      result: {
+        value: {
+          marker: {
+            protocolVersion: STAGEHAND_PROTOCOL_VERSION,
+            serverInfo: { name: "other", version: "1.0.0" },
+          },
+          hasReceiver: true,
+        },
+      },
+    }));
+
+    const error = await rejectedError(
+      waitForRuntimeReady(cdp, "worker-session", {
+        pollIntervalMs: 1,
+        signal: lifecycleSignal,
+        delayFn: async () => {
+          delays += 1;
+        },
+      }),
+    );
+
+    expect(error).toBeInstanceOf(StagehandRuntimeIncompatibleError);
+    expect((error as StagehandRuntimeIncompatibleError).reason).toBe("runtime-name-mismatch");
+    expect((error as StagehandRuntimeIncompatibleError).serverInfo.name).toBe("other");
+    expect(cdp.calls.filter((call) => call.method === "Runtime.evaluate")).toHaveLength(1);
+    expect(delays).toBe(0);
+  });
+
+  it("keeps polling an unknown marker until a compatible runtime appears", async () => {
+    const results = [
+      { result: { value: { marker: null, hasReceiver: false } } },
+      { result: { value: { marker: null, hasReceiver: false } } },
+      { result: { value: { marker: null, hasReceiver: true } } },
+      { result: { value: readyRuntime() } },
+    ];
+    const cdp = new FakeCdp().on("Runtime.evaluate", () => results.shift() ?? {});
+
+    await expect(
+      waitForRuntimeReady(cdp, "worker-session", {
+        pollIntervalMs: 1,
+        delayFn: async () => {},
+        signal: lifecycleSignal,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(cdp.calls.filter((call) => call.method === "Runtime.evaluate")).toHaveLength(4);
+  });
+
+  it("keeps polling an out-of-range runtime when fallback installation is explicitly allowed", async () => {
     const controller = new AbortController();
     const reason = new Error("initialization cancelled");
     const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
@@ -402,6 +456,7 @@ describe("waitForRuntimeReady", () => {
     const error = await rejectedError(
       waitForRuntimeReady(cdp, "worker-session", {
         pollIntervalMs: 1,
+        allowFallbackInstall: true,
         signal: controller.signal,
         delayFn: async () => {
           controller.abort(reason);
@@ -410,6 +465,7 @@ describe("waitForRuntimeReady", () => {
     );
 
     expect(error).toBe(reason);
+    expect(cdp.calls.filter((call) => call.method === "Runtime.evaluate")).toHaveLength(1);
   });
 
   it("throws for an out-of-range attached runtime when fallback installation is disabled", async () => {

--- a/packages/sdk-ts/tests/cdpClientLifecycle.test.ts
+++ b/packages/sdk-ts/tests/cdpClientLifecycle.test.ts
@@ -385,6 +385,10 @@ describe("waitForRuntimeReady", () => {
     expect(error).toBeInstanceOf(StagehandRuntimeIncompatibleError);
     const incompatible = error as StagehandRuntimeIncompatibleError;
     expect(incompatible.reason).toBe("protocol-major-mismatch");
+    expect(incompatible.detail).toBe(
+      `Protocol major mismatch: client ${STAGEHAND_PROTOCOL_VERSION}, server ${incompatibleProtocolVersion}`,
+    );
+    expect(incompatible.message).toContain(incompatible.detail);
     expect(incompatible.clientProtocolVersion).toBe(STAGEHAND_PROTOCOL_VERSION);
     expect(incompatible.reportedProtocolVersion).toBe(incompatibleProtocolVersion);
     expect(incompatible.serverInfo).toStrictEqual({ name: "stagehand", version: "1.0.0" });

--- a/packages/sdk-ts/tests/runtimeCompatibility.test.ts
+++ b/packages/sdk-ts/tests/runtimeCompatibility.test.ts
@@ -75,15 +75,20 @@ describe("negotiateRuntimeCompatibility", () => {
         reason: "unreadable-marker",
       }),
   );
-  it("reports a foreign marker as unreadable", () =>
+  it("reports a foreign runtime as incompatible", () =>
     expect(
       negotiateRuntimeCompatibility(requirement, {
         ...marker("1.2.4"),
         serverInfo: { name: "other", version: "1.0.0" },
       }),
     ).toMatchObject({
-      kind: "unknown",
-      reason: "unreadable-marker",
+      kind: "incompatible",
+      reason: "runtime-name-mismatch",
+      required: { protocolVersion: "1.2.4" },
+      reported: {
+        protocolVersion: "1.2.4",
+        serverInfo: { name: "other", version: "1.0.0" },
+      },
     }));
   it("reports unknown marker keys as unreadable", () =>
     expect(

--- a/packages/sdk-ts/tests/runtimeCompatibility.test.ts
+++ b/packages/sdk-ts/tests/runtimeCompatibility.test.ts
@@ -104,6 +104,7 @@ describe("negotiateRuntimeCompatibility", () => {
     ).toMatchObject({
       kind: "incompatible",
       reason: "runtime-name-mismatch",
+      detail: 'Runtime name mismatch: expected "stagehand", server reported "other"',
       required: { protocolVersion: "1.2.4" },
       reported: {
         protocolVersion: "1.2.4",

--- a/packages/sdk-ts/tests/runtimeCompatibility.test.ts
+++ b/packages/sdk-ts/tests/runtimeCompatibility.test.ts
@@ -60,6 +60,26 @@ describe("negotiateRuntimeCompatibility", () => {
       kind: "incompatible",
       reason: "protocol-invalid-version",
     }));
+  it("reports a non-SemVer reported protocol version as incompatible, not unknown", () =>
+    expect(negotiateRuntimeCompatibility(requirement, marker("not-semver"))).toMatchObject({
+      kind: "incompatible",
+      reason: "protocol-invalid-version",
+      detail: "Invalid protocol version: client 1.2.4, server not-semver",
+      reported: {
+        protocolVersion: "not-semver",
+        serverInfo: { name: "stagehand", version: "1.0.0" },
+      },
+    }));
+  it.each([
+    [{ ...marker("1.2.4"), serverInfo: { name: "", version: "1.0.0" } }],
+    [{ ...marker("1.2.4"), serverInfo: { name: "stagehand", version: "" } }],
+    [{ protocolVersion: "", serverInfo: { name: "stagehand", version: "1.0.0" } }],
+  ])("reports a marker with an empty field as unreadable for %j", (raw) =>
+    expect(negotiateRuntimeCompatibility(requirement, raw)).toMatchObject({
+      kind: "unknown",
+      reason: "unreadable-marker",
+    }),
+  );
   it.each([[null], [undefined]])("reports a missing marker for %s", (raw) =>
     expect(negotiateRuntimeCompatibility(requirement, raw)).toMatchObject({
       kind: "unknown",


### PR DESCRIPTION
## Why

When the connected Stagehand extension publishes a runtime marker whose protocol this SDK cannot use (major mismatch, server minor too old, prerelease mismatch, or a non-Stagehand `serverInfo.name`), the readiness loop kept re-polling `Runtime.evaluate` every 100 ms until the generic 60 s deadline fired with `Stagehand initialization timed out after 60000ms`. The user got no hint that the real problem was a protocol mismatch.

Root cause: the TS guard was `compatibility.kind === "incompatible" && options.allowFallbackInstall === false`. Nobody sets `allowFallbackInstall`, so the check never fired. Python and Go collapsed "incompatible" and "marker not there yet" into a single `false`, so they had no way to stop polling either.

## What changed

Behavior is identical across the three SDKs: negotiation is three-way (`compatible` / `incompatible` / `unknown`). `unknown` (marker absent, not yet set, unparseable, or `Runtime.evaluate` threw) keeps polling as before. `incompatible` fails on the **first** poll with a dedicated, catchable error carrying the reason, client protocol version, reported protocol version, extension `serverInfo` (name + version), and a one-line remediation hint. `allowFallbackInstall` is kept (reserved for a future Browserbase preloaded-extension flow) but its default flips: only an explicit `true` keeps polling.

## Test plan

Per SDK, new tests cover: 
(a) incompatible marker → dedicated error on the first poll (exactly one `Runtime.evaluate`, delay never awaited / hour-long poll interval not waited); 
(b) unknown marker for N polls then compatible → succeeds after N+1 evaluates; 
(c) `allowFallbackInstall: true` + incompatible → keeps polling until cancelled (TS, Python, Go); 
(d) wrong `serverInfo.name` → error with `runtime-name-mismatch`. Incompatible versions are derived from `STAGEHAND_PROTOCOL_VERSION` (major+1), per #2908/#2909. Fixtures that asserted the old hang on incompatible / foreign markers were flipped or replaced.

- [x] `pnpm --filter ./packages/sdk-ts exec vitest run --root ../.. packages/sdk-ts/tests` — 274 passed
- [x] `pnpm --filter ./packages/sdk-ts typecheck`
- [x] `cd packages/sdk-python && uv run --locked pytest` — 520 passed, 1 skipped; `ruff format --check`, `ruff check`, `ty check` clean
- [x] `go -C packages/sdk-go test ./...` (excl. examples) + generator tests — ok
- [x] `just fmt` / `just check` equivalents (oxfmt, `pnpm check` 34/34, changeset check, changelog + python-version sync checks, uv lock check, generator `--check`, extensionpack `--check`, gofmt, go vet) — all green
- [x] `pnpm test` (turbo `test:unit test:browser`) — 33/33 tasks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails fast with a dedicated, catchable error when the connected Stagehand extension reports an incompatible protocol version, instead of polling until the initialization timeout. This applies consistently across `@browserbasehq/stagehand`, `stagehand` (Python), and `stagehand-go`.

**What changed**

- Runtime negotiation is now three-way: `compatible`, `incompatible`, and `unknown`. Unknown keeps polling; incompatible fails on the first poll.
- New `StagehandRuntimeIncompatibleError` (TS/Python) and `RuntimeIncompatibleError` (Go) include the reason, client and reported protocol versions, server info, and a remediation hint. They are exported from each package entry so callers can catch them with `instanceof` or `errors.As`.
- `allowFallbackInstall` now only suppresses the error when explicitly `true`; the default is fail-fast.
- A foreign `serverInfo.name` is classified as incompatible (`runtime-name-mismatch`); markers with empty or non-string `serverInfo` fields or an empty `protocolVersion` keep polling as unknown.
- Non-SemVer protocol versions now fail fast as `protocol-invalid-version` instead of polling; error messages and detail wording match across the SDKs.

<sup>Written for commit 62613624f5c2ba5f17c0b4ab4e33fbddb78e6134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

