### PR TITLE
[fix]: fail fast on incompatible Stagehand runtime instead of polling to timeout

### DIFF
--- a/.changeset/fail-fast-incompatible-runtime.md
+++ b/.changeset/fail-fast-incompatible-runtime.md
@@ -4,4 +4,4 @@
 "@browserbasehq/stagehand-go": patch
 ---
 
-Fail fast on a protocol compatibility errors
+Fail fast on protocol compatibility errors

--- a/.changeset/fail-fast-incompatible-runtime.md
+++ b/.changeset/fail-fast-incompatible-runtime.md
@@ -4,4 +4,4 @@
 "@browserbasehq/stagehand-go": patch
 ---
 
-Fail fast with a protocol compatibility error when the connected Stagehand extension reports an incompatible protocol version, instead of polling until the initialization timeout.
+Fail fast on a protocol compatibility errors

--- a/.changeset/fail-fast-incompatible-runtime.md
+++ b/.changeset/fail-fast-incompatible-runtime.md
@@ -1,0 +1,7 @@
+---
+"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand-python": patch
+"@browserbasehq/stagehand-go": patch
+---
+
+Fail fast with a protocol compatibility error when the connected Stagehand extension reports an incompatible protocol version, instead of polling until the initialization timeout.

--- a/packages/extension/tests/stagehand-clients.test.ts
+++ b/packages/extension/tests/stagehand-clients.test.ts
@@ -9,6 +9,7 @@ import {
   StagehandSendToHostBindingSchema,
 } from "../../protocol/schema-registry.ts";
 import { startStagehandServiceWorker } from "../service-worker.ts";
+import { STAGEHAND_RUNTIME_VERSION } from "../version.ts";
 import type {
   StagehandBrowserSession,
   UnderstudyRuntimeClipboardOptions,
@@ -804,7 +805,7 @@ describe("Stagehand worker clients", () => {
         protocolVersion: STAGEHAND_PROTOCOL_VERSION,
         serverInfo: {
           name: "stagehand",
-          version: "1.0.0",
+          version: STAGEHAND_RUNTIME_VERSION,
         },
       },
       __stagehandReceiveFromHost: expect.any(Function),

--- a/packages/protocol/tests/rpc-client/cdp-client.test.ts
+++ b/packages/protocol/tests/rpc-client/cdp-client.test.ts
@@ -29,11 +29,16 @@ type TargetInfo = {
 
 type FakeCdpResult = Record<string, unknown>;
 
+type FakeCdpHandler = (
+  params?: Record<string, unknown>,
+  sessionId?: string,
+) => FakeCdpResult | Promise<FakeCdpResult>;
+
 class FakeCdp {
   readonly calls: CdpCall[] = [];
-  handlers = new Map<string, () => FakeCdpResult | Promise<FakeCdpResult>>();
+  handlers = new Map<string, FakeCdpHandler>();
 
-  on(method: string, handler: () => FakeCdpResult | Promise<FakeCdpResult>): this {
+  on(method: string, handler: FakeCdpHandler): this {
     this.handlers.set(method, handler);
     return this;
   }
@@ -51,7 +56,7 @@ class FakeCdp {
       return {} as Result;
     }
 
-    return (await handler()) as Result;
+    return (await handler(params, sessionId)) as Result;
   }
 }
 
@@ -391,6 +396,44 @@ describe("waitForPreloadedStagehandServiceWorker", () => {
       sessionId: undefined,
       signal: lifecycleSignal,
     });
+  });
+  it("keeps sweeping when a compatible worker lacks its receiver even if a sibling is incompatible", async () => {
+    const pendingWorker = target(
+      "pending-worker",
+      "chrome-extension://pendingext/service-worker.js",
+    );
+    const staleWorker = target("stale-worker", "chrome-extension://staleext/service-worker.js");
+    let sweeps = 0;
+    const cdp = new FakeCdp()
+      .on("Target.getTargets", () => {
+        sweeps += 1;
+        return { targetInfos: [pendingWorker, staleWorker] };
+      })
+      .on("Target.attachToTarget", (params) => ({
+        sessionId: `${String(params?.targetId).replace("-worker", "")}-session`,
+      }))
+      .on("Runtime.evaluate", (_params, sessionId) => {
+        if (sessionId === "stale-session") {
+          return { result: { value: runtimeReadiness(NEXT_MAJOR_PROTOCOL_VERSION) } };
+        }
+        return {
+          result: {
+            value: sweeps === 1 ? { ...readyRuntime(), hasReceiver: false } : readyRuntime(),
+          },
+        };
+      })
+      .on("Target.detachFromTarget", () => ({}));
+
+    await expect(
+      waitForPreloadedStagehandServiceWorker(cdp, {
+        delayFn: async () => {},
+        signal: lifecycleSignal,
+      }),
+    ).resolves.toStrictEqual({
+      serviceWorker: pendingWorker,
+      sessionId: "pending-session",
+    });
+    expect(sweeps).toBe(2);
   });
 });
 

--- a/packages/protocol/tests/rpc-client/cdp-client.test.ts
+++ b/packages/protocol/tests/rpc-client/cdp-client.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { STAGEHAND_PROTOCOL_VERSION } from "../../schemas.ts";
+
+const NEXT_MAJOR_PROTOCOL_VERSION = `${Number(STAGEHAND_PROTOCOL_VERSION.split(".")[0]) + 1}.0.0`;
 import {
   loadUnpackedExtension,
   resolveBrowserWebSocketUrl,
@@ -302,7 +304,7 @@ describe("waitForPreloadedStagehandServiceWorker", () => {
     });
   });
 
-  it("keeps looking past a stale runtime until initialization is cancelled", async () => {
+  it("keeps looking past a stale runtime when fallback install is allowed", async () => {
     const controller = new AbortController();
     const reason = new Error("initialization cancelled");
     const staleWorker = target("stale-worker", "chrome-extension://staleext/service-worker.js");
@@ -316,6 +318,7 @@ describe("waitForPreloadedStagehandServiceWorker", () => {
 
     const error = await rejectedError(
       waitForPreloadedStagehandServiceWorker(cdp, {
+        allowFallbackInstall: true,
         pollIntervalMs: 1,
         signal: controller.signal,
         delayFn: async () => {
@@ -449,7 +452,7 @@ describe("waitForRuntimeReady", () => {
     expect(cdp.calls.filter((call) => call.method === "Runtime.evaluate")).toHaveLength(2);
   });
 
-  it("keeps polling a non-Stagehand runtime until initialization is cancelled", async () => {
+  it("keeps polling a non-Stagehand runtime when fallback install is allowed", async () => {
     const controller = new AbortController();
     const reason = new Error("initialization cancelled");
     const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
@@ -466,6 +469,7 @@ describe("waitForRuntimeReady", () => {
 
     await expect(
       waitForRuntimeReady(cdp, "worker-session", {
+        allowFallbackInstall: true,
         pollIntervalMs: 1,
         signal: controller.signal,
         delayFn: async () => {
@@ -519,7 +523,7 @@ describe("waitForRuntimeReady", () => {
     expect(error).toBe(reason);
   });
 
-  it("keeps polling an out-of-range runtime by default until initialization is cancelled", async () => {
+  it("keeps polling an out-of-range runtime when fallback install is allowed", async () => {
     const controller = new AbortController();
     const reason = new Error("initialization cancelled");
     const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
@@ -528,6 +532,7 @@ describe("waitForRuntimeReady", () => {
 
     const error = await rejectedError(
       waitForRuntimeReady(cdp, "worker-session", {
+        allowFallbackInstall: true,
         pollIntervalMs: 1,
         signal: controller.signal,
         delayFn: async () => {
@@ -537,6 +542,55 @@ describe("waitForRuntimeReady", () => {
     );
 
     expect(error).toBe(reason);
+  });
+
+  it("rejects an out-of-range runtime on the first poll by default", async () => {
+    const delays: number[] = [];
+    const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
+      result: { value: runtimeReadiness(NEXT_MAJOR_PROTOCOL_VERSION) },
+    }));
+
+    const error = await rejectedError(
+      waitForRuntimeReady(cdp, "worker-session", {
+        signal: new AbortController().signal,
+        delayFn: async (ms) => {
+          delays.push(ms);
+        },
+      }),
+    );
+
+    expect(error).toBeInstanceOf(StagehandRuntimeIncompatibleError);
+    expect((error as StagehandRuntimeIncompatibleError).reason).toBe("protocol-major-mismatch");
+    expect(delays).toEqual([]);
+    expect(cdp.calls.filter((call) => call.method === "Runtime.evaluate")).toHaveLength(1);
+  });
+
+  it("rejects a non-Stagehand runtime on the first poll by default", async () => {
+    const delays: number[] = [];
+    const cdp = new FakeCdp().on("Runtime.evaluate", () => ({
+      result: {
+        value: {
+          marker: {
+            protocolVersion: STAGEHAND_PROTOCOL_VERSION,
+            serverInfo: { name: "other-extension", version: "1" },
+          },
+          hasReceiver: false,
+        },
+      },
+    }));
+
+    const error = await rejectedError(
+      waitForRuntimeReady(cdp, "worker-session", {
+        signal: new AbortController().signal,
+        delayFn: async (ms) => {
+          delays.push(ms);
+        },
+      }),
+    );
+
+    expect(error).toBeInstanceOf(StagehandRuntimeIncompatibleError);
+    expect(delays).toEqual([]);
+    expect(cdp.calls.filter((call) => call.method === "Runtime.evaluate")).toHaveLength(1);
   });
 
   it("throws for an out-of-range attached runtime when fallback installation is disabled", async () => {

--- a/packages/sdk-go/cdp_client.go
+++ b/packages/sdk-go/cdp_client.go
@@ -897,6 +897,9 @@ func (c *cdpClient) waitForPreloadedServiceWorker(
 		}
 		lastTargets = targets
 		var incompatibleRuntime *RuntimeIncompatibleError
+		// A compatible worker whose receiver is not installed yet must keep the
+		// sweep polling even when a sibling worker is incompatible.
+		sawCompatibleMarker := false
 		for _, target := range targets {
 			if !isStagehandServiceWorker(target, "", urlIncludes) {
 				continue
@@ -914,8 +917,8 @@ func (c *cdpClient) waitForPreloadedServiceWorker(
 			if err != nil || attached.SessionID == "" {
 				continue
 			}
-			ready, _, incompatible := c.evaluateRuntimeReadiness(ctx, attached.SessionID)
-			if ready {
+			readiness := c.evaluateRuntimeReadiness(ctx, attached.SessionID)
+			if readiness.ready {
 				return target, attached.SessionID, nil
 			}
 			c.bestEffortCommand(
@@ -923,13 +926,16 @@ func (c *cdpClient) waitForPreloadedServiceWorker(
 				"Target.detachFromTarget",
 				map[string]any{"sessionId": attached.SessionID},
 			)
-			if incompatible != nil && !allowFallbackInstall {
-				incompatibleRuntime = incompatible
+			if readiness.compatibleMarker {
+				sawCompatibleMarker = true
+			}
+			if readiness.incompatible != nil && !allowFallbackInstall {
+				incompatibleRuntime = readiness.incompatible
 			}
 		}
-		// No compatible worker in this sweep and at least one incompatible one:
+		// No compatible marker in this sweep and at least one incompatible one:
 		// fail fast instead of re-polling until the initialization deadline.
-		if incompatibleRuntime != nil {
+		if incompatibleRuntime != nil && !sawCompatibleMarker {
 			return cdpTargetInfo{}, "", incompatibleRuntime
 		}
 		if err := waitForCDPPoll(ctx, pollInterval); err != nil {
@@ -975,32 +981,44 @@ func (c *cdpClient) waitForRuntimeReady(
 				err,
 			)
 		}
-		ready, detail, incompatible := c.evaluateRuntimeReadiness(ctx, sessionID)
-		if ready {
+		readiness := c.evaluateRuntimeReadiness(ctx, sessionID)
+		if readiness.ready {
 			return nil
 		}
-		if incompatible != nil && !allowFallbackInstall {
+		if readiness.incompatible != nil && !allowFallbackInstall {
 			// Fail fast: an incompatible marker will not become compatible
 			// by waiting, so do not sleep for another poll.
-			return incompatible
+			return readiness.incompatible
 		}
-		lastError = detail
+		lastError = readiness.detail
 		if err := waitForCDPPoll(ctx, pollInterval); err != nil {
 			continue
 		}
 	}
 }
 
+// runtimeReadinessOutcome is one Runtime.evaluate probe of the extension's
+// runtime marker and receiver binding.
+type runtimeReadinessOutcome struct {
+	// ready is true when the runtime is compatible and the receiver is installed.
+	ready bool
+	// compatibleMarker is true when the marker negotiated as compatible, even
+	// if the receiver is not installed yet.
+	compatibleMarker bool
+	// detail explains why the caller should keep waiting when ready is false.
+	detail string
+	// incompatible is set when the marker is present but incompatible so
+	// callers can stop polling; it is nil for absent/unreadable markers and
+	// evaluation failures.
+	incompatible *RuntimeIncompatibleError
+}
+
 // evaluateRuntimeReadiness reads the extension's runtime marker and receiver
-// binding over CDP. It reports ready=true when the runtime is compatible and
-// the receiver is installed. When the marker is present but incompatible it
-// also returns a *RuntimeIncompatibleError so callers can stop polling; on an
-// absent/unreadable marker or an evaluation failure the error is nil and the
-// detail explains why the caller should keep waiting.
+// binding over CDP and classifies the outcome (see runtimeReadinessOutcome).
 func (c *cdpClient) evaluateRuntimeReadiness(
 	ctx context.Context,
 	sessionID string,
-) (bool, string, *RuntimeIncompatibleError) {
+) runtimeReadinessOutcome {
 	var evaluated cdpRuntimeEvaluateResult
 	err := c.sendCommand(
 		ctx,
@@ -1013,32 +1031,36 @@ func (c *cdpClient) evaluateRuntimeReadiness(
 		&evaluated,
 	)
 	if err != nil {
-		return false, err.Error(), nil
+		return runtimeReadinessOutcome{detail: err.Error()}
 	}
 	if evaluated.ExceptionDetails != nil {
-		return false, runtimeExceptionMessage(
+		return runtimeReadinessOutcome{detail: runtimeExceptionMessage(
 			evaluated.ExceptionDetails,
 			"readiness evaluation threw",
-		), nil
+		)}
 	}
 	if evaluated.Result == nil || len(evaluated.Result.Value) == 0 {
-		return false, "readiness evaluation returned no value", nil
+		return runtimeReadinessOutcome{detail: "readiness evaluation returned no value"}
 	}
 	var readiness cdpRuntimeReadiness
 	if err := json.Unmarshal(evaluated.Result.Value, &readiness); err != nil {
-		return false, "readiness evaluation returned an invalid value", nil
+		return runtimeReadinessOutcome{detail: "readiness evaluation returned an invalid value"}
 	}
 	compat := negotiateRuntimeCompatibility(readiness.Marker)
-	if compat.Kind == runtimeCompatibilityCompatible && readiness.HasReceiver {
-		return true, "", nil
+	compatibleMarker := compat.Kind == runtimeCompatibilityCompatible
+	if compatibleMarker && readiness.HasReceiver {
+		return runtimeReadinessOutcome{ready: true, compatibleMarker: true}
 	}
-	detail := fmt.Sprintf(
-		"runtime %s (%s), __stagehandReceiveFromHost=%t",
-		compat.Kind,
-		compat.Detail,
-		readiness.HasReceiver,
-	)
-	return false, detail, compat.incompatibleError()
+	return runtimeReadinessOutcome{
+		compatibleMarker: compatibleMarker,
+		detail: fmt.Sprintf(
+			"runtime %s (%s), __stagehandReceiveFromHost=%t",
+			compat.Kind,
+			compat.Detail,
+			readiness.HasReceiver,
+		),
+		incompatible: compat.incompatibleError(),
+	}
 }
 
 func (c *cdpClient) bestEffortCommand(ctx context.Context, method string, params any) {

--- a/packages/sdk-go/cdp_client.go
+++ b/packages/sdk-go/cdp_client.go
@@ -60,9 +60,13 @@ type cdpClientOptions struct {
 	extensionID              string
 	preloadedExtension       bool
 	serviceWorkerURLIncludes string
-	pollInterval             time.Duration
-	activationDelay          time.Duration
-	httpClient               *http.Client
+	// allowFallbackInstall keeps polling when the extension reports an
+	// incompatible protocol instead of failing fast. It is reserved for a
+	// future Browserbase preloaded-extension flow and defaults to false.
+	allowFallbackInstall bool
+	pollInterval         time.Duration
+	activationDelay      time.Duration
+	httpClient           *http.Client
 }
 
 type cdpClient struct {
@@ -299,6 +303,7 @@ func (c *cdpClient) initialize(ctx context.Context, options cdpClientOptions) er
 			ctx,
 			options.serviceWorkerURLIncludes,
 			options.pollInterval,
+			options.allowFallbackInstall,
 		)
 		if err != nil {
 			return err
@@ -371,6 +376,7 @@ func (c *cdpClient) initialize(ctx context.Context, options cdpClientOptions) er
 		ctx,
 		sessionID,
 		options.pollInterval,
+		options.allowFallbackInstall,
 	)
 }
 
@@ -873,6 +879,7 @@ func (c *cdpClient) waitForPreloadedServiceWorker(
 	ctx context.Context,
 	urlIncludes string,
 	pollInterval time.Duration,
+	allowFallbackInstall bool,
 ) (cdpTargetInfo, string, error) {
 	var lastTargets []cdpTargetInfo
 
@@ -889,6 +896,7 @@ func (c *cdpClient) waitForPreloadedServiceWorker(
 			return cdpTargetInfo{}, "", err
 		}
 		lastTargets = targets
+		var incompatibleRuntime *RuntimeIncompatibleError
 		for _, target := range targets {
 			if !isStagehandServiceWorker(target, "", urlIncludes) {
 				continue
@@ -906,7 +914,7 @@ func (c *cdpClient) waitForPreloadedServiceWorker(
 			if err != nil || attached.SessionID == "" {
 				continue
 			}
-			ready, _ := c.evaluateRuntimeReadiness(ctx, attached.SessionID)
+			ready, _, incompatible := c.evaluateRuntimeReadiness(ctx, attached.SessionID)
 			if ready {
 				return target, attached.SessionID, nil
 			}
@@ -915,6 +923,14 @@ func (c *cdpClient) waitForPreloadedServiceWorker(
 				"Target.detachFromTarget",
 				map[string]any{"sessionId": attached.SessionID},
 			)
+			if incompatible != nil && !allowFallbackInstall {
+				incompatibleRuntime = incompatible
+			}
+		}
+		// No compatible worker in this sweep and at least one incompatible one:
+		// fail fast instead of re-polling until the initialization deadline.
+		if incompatibleRuntime != nil {
+			return cdpTargetInfo{}, "", incompatibleRuntime
 		}
 		if err := waitForCDPPoll(ctx, pollInterval); err != nil {
 			continue
@@ -942,6 +958,7 @@ func (c *cdpClient) waitForRuntimeReady(
 	ctx context.Context,
 	sessionID string,
 	pollInterval time.Duration,
+	allowFallbackInstall bool,
 ) error {
 	lastError := ""
 	for {
@@ -958,9 +975,14 @@ func (c *cdpClient) waitForRuntimeReady(
 				err,
 			)
 		}
-		ready, detail := c.evaluateRuntimeReadiness(ctx, sessionID)
+		ready, detail, incompatible := c.evaluateRuntimeReadiness(ctx, sessionID)
 		if ready {
 			return nil
+		}
+		if incompatible != nil && !allowFallbackInstall {
+			// Fail fast: an incompatible marker will not become compatible
+			// by waiting, so do not sleep for another poll.
+			return incompatible
 		}
 		lastError = detail
 		if err := waitForCDPPoll(ctx, pollInterval); err != nil {
@@ -969,10 +991,16 @@ func (c *cdpClient) waitForRuntimeReady(
 	}
 }
 
+// evaluateRuntimeReadiness reads the extension's runtime marker and receiver
+// binding over CDP. It reports ready=true when the runtime is compatible and
+// the receiver is installed. When the marker is present but incompatible it
+// also returns a *RuntimeIncompatibleError so callers can stop polling; on an
+// absent/unreadable marker or an evaluation failure the error is nil and the
+// detail explains why the caller should keep waiting.
 func (c *cdpClient) evaluateRuntimeReadiness(
 	ctx context.Context,
 	sessionID string,
-) (bool, string) {
+) (bool, string, *RuntimeIncompatibleError) {
 	var evaluated cdpRuntimeEvaluateResult
 	err := c.sendCommand(
 		ctx,
@@ -985,30 +1013,32 @@ func (c *cdpClient) evaluateRuntimeReadiness(
 		&evaluated,
 	)
 	if err != nil {
-		return false, err.Error()
+		return false, err.Error(), nil
 	}
 	if evaluated.ExceptionDetails != nil {
 		return false, runtimeExceptionMessage(
 			evaluated.ExceptionDetails,
 			"readiness evaluation threw",
-		)
+		), nil
 	}
 	if evaluated.Result == nil || len(evaluated.Result.Value) == 0 {
-		return false, "readiness evaluation returned no value"
+		return false, "readiness evaluation returned no value", nil
 	}
 	var readiness cdpRuntimeReadiness
 	if err := json.Unmarshal(evaluated.Result.Value, &readiness); err != nil {
-		return false, "readiness evaluation returned an invalid value"
+		return false, "readiness evaluation returned an invalid value", nil
 	}
-	compatible, detail := negotiateRuntimeCompatibility(readiness.Marker)
-	if compatible && readiness.HasReceiver {
-		return true, ""
+	compat := negotiateRuntimeCompatibility(readiness.Marker)
+	if compat.Kind == runtimeCompatibilityCompatible && readiness.HasReceiver {
+		return true, "", nil
 	}
-	return false, fmt.Sprintf(
-		"runtime %s, __stagehandReceiveFromHost=%t",
-		detail,
+	detail := fmt.Sprintf(
+		"runtime %s (%s), __stagehandReceiveFromHost=%t",
+		compat.Kind,
+		compat.Detail,
 		readiness.HasReceiver,
 	)
+	return false, detail, compat.incompatibleError()
 }
 
 func (c *cdpClient) bestEffortCommand(ctx context.Context, method string, params any) {

--- a/packages/sdk-go/cdp_client_test.go
+++ b/packages/sdk-go/cdp_client_test.go
@@ -1221,6 +1221,92 @@ func TestCDPClientAllowFallbackInstallKeepsPollingIncompatibleRuntime(t *testing
 	}
 }
 
+func TestCDPClientPreloadedExtensionKeepsSweepingWhenCompatibleWorkerLacksReceiver(t *testing.T) {
+	t.Parallel()
+
+	// Sweep 1: a compatible worker has published its marker but not installed the
+	// receiver yet, and a stale sibling worker is incompatible. Sweep 2: the
+	// compatible worker is ready. The incompatible sibling must not fail fast.
+	socket := newFakeCDPWebSocket()
+	methods := make(chan string, 64)
+	var sweeps atomic.Int32
+	socket.writeHook = responseHook(t, socket, methods, func(
+		method string,
+		command map[string]json.RawMessage,
+	) map[string]any {
+		switch method {
+		case "Target.getTargets":
+			sweeps.Add(1)
+			return map[string]any{"result": map[string]any{
+				"targetInfos": []map[string]any{
+					{
+						"targetId": "pending-target",
+						"type":     "service_worker",
+						"title":    "Stagehand",
+						"url":      "chrome-extension://pending/service-worker.js",
+					},
+					{
+						"targetId": "stale-target",
+						"type":     "service_worker",
+						"title":    "Stagehand (stale)",
+						"url":      "chrome-extension://stale/service-worker.js",
+					},
+				},
+			}}
+		case "Target.attachToTarget":
+			var params struct {
+				TargetID string `json:"targetId"`
+			}
+			if err := json.Unmarshal(command["params"], &params); err != nil {
+				t.Errorf("decode attach params: %v", err)
+			}
+			return map[string]any{"result": map[string]any{
+				"sessionId": strings.TrimSuffix(params.TargetID, "-target") + "-session",
+			}}
+		case "Runtime.evaluate":
+			var sessionID string
+			_ = json.Unmarshal(command["sessionId"], &sessionID)
+			if sessionID == "stale-session" {
+				return runtimeMarkerResponse(incompatibleRuntimeMarker(t), true)
+			}
+			return runtimeMarkerResponse(compatibleRuntimeMarker(), sweeps.Load() > 1)
+		default:
+			return map[string]any{"result": map[string]any{}}
+		}
+	})
+	client := newTestCDPClient(t, socket, "ws://127.0.0.1/devtools/browser/test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.initialize(ctx, normalizeCDPClientOptions(cdpClientOptions{
+		preloadedExtension: true,
+		pollInterval:       time.Millisecond,
+	}))
+	if err != nil {
+		t.Fatalf("initialize() error = %v, want the compatible worker to be selected", err)
+	}
+
+	client.mu.Lock()
+	service := client.service
+	client.mu.Unlock()
+	if service.ExtensionID != "pending" {
+		t.Fatalf("extension ID = %q, want %q", service.ExtensionID, "pending")
+	}
+	if got := sweeps.Load(); got != 2 {
+		t.Fatalf("Target.getTargets sweeps = %d, want exactly 2", got)
+	}
+	detaches := 0
+	for _, method := range drainMethods(methods) {
+		if method == "Target.detachFromTarget" {
+			detaches++
+		}
+	}
+	// Both probed workers are detached in sweep 1; sweep 2 keeps the ready worker attached.
+	if detaches != 2 {
+		t.Fatalf("Target.detachFromTarget calls = %d, want 2", detaches)
+	}
+}
+
 func TestCDPClientPreloadedExtensionFailsFastOnIncompatibleRuntime(t *testing.T) {
 	t.Parallel()
 

--- a/packages/sdk-go/cdp_client_test.go
+++ b/packages/sdk-go/cdp_client_test.go
@@ -1010,3 +1010,273 @@ func assertJSONEqual(t *testing.T, actual json.RawMessage, expected string) {
 		t.Fatalf("JSON mismatch\nactual:   %s\nexpected: %s", actual, expected)
 	}
 }
+
+// runtimeMarkerResponse builds a Runtime.evaluate result for the readiness
+// expression with an arbitrary marker payload.
+func runtimeMarkerResponse(marker any, hasReceiver bool) map[string]any {
+	return map[string]any{"result": map[string]any{
+		"result": map[string]any{
+			"value": map[string]any{
+				"marker":      marker,
+				"hasReceiver": hasReceiver,
+			},
+		},
+	}}
+}
+
+func incompatibleRuntimeMarker(t *testing.T) map[string]any {
+	t.Helper()
+	return map[string]any{
+		"protocolVersion": incompatibleMajorProtocolVersion(t),
+		"serverInfo": map[string]any{
+			"name":    stagehandRuntimeName,
+			"version": "9.9.9",
+		},
+	}
+}
+
+func compatibleRuntimeMarker() map[string]any {
+	return map[string]any{
+		"protocolVersion": stagehandProtocolVersion,
+		"serverInfo": map[string]any{
+			"name":    stagehandRuntimeName,
+			"version": stagehandSDKVersion,
+		},
+	}
+}
+
+func runtimeExceptionResponse() map[string]any {
+	return map[string]any{"result": map[string]any{
+		"exceptionDetails": map[string]any{"text": "Uncaught"},
+	}}
+}
+
+// loadedExtensionResponder answers the non-readiness CDP commands issued by
+// initialize() for the extensionDir flow and delegates Runtime.evaluate to
+// evaluate, which is invoked once per readiness poll.
+func loadedExtensionResponder(
+	evaluate func(poll int) map[string]any,
+) (func(string, map[string]json.RawMessage) map[string]any, *atomic.Int32) {
+	var polls atomic.Int32
+	return func(method string, _ map[string]json.RawMessage) map[string]any {
+		switch method {
+		case "Extensions.loadUnpacked":
+			return map[string]any{"result": map[string]any{"id": "stagehand-extension"}}
+		case "Target.getTargets":
+			return map[string]any{"result": map[string]any{
+				"targetInfos": []map[string]any{{
+					"targetId": "worker-target",
+					"type":     "service_worker",
+					"title":    "Stagehand",
+					"url":      "chrome-extension://stagehand-extension/service-worker.js",
+				}},
+			}}
+		case "Target.attachToTarget":
+			return map[string]any{"result": map[string]any{"sessionId": "worker-session"}}
+		case "Runtime.evaluate":
+			return evaluate(int(polls.Add(1)))
+		default:
+			return map[string]any{"result": map[string]any{}}
+		}
+	}, &polls
+}
+
+func TestCDPClientFailsFastOnIncompatibleRuntime(t *testing.T) {
+	t.Parallel()
+
+	socket := newFakeCDPWebSocket()
+	responder, polls := loadedExtensionResponder(func(int) map[string]any {
+		return runtimeMarkerResponse(incompatibleRuntimeMarker(t), true)
+	})
+	socket.writeHook = responseHook(t, socket, nil, responder)
+	client := newTestCDPClient(t, socket, "ws://127.0.0.1/devtools/browser/test")
+
+	// A one-hour poll interval proves the loop never slept: if it had, the
+	// context deadline (not the compatibility error) would end the test.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	started := time.Now()
+	err := client.initialize(ctx, normalizeCDPClientOptions(cdpClientOptions{
+		extensionDir: "/tmp/stagehand-extension",
+		pollInterval: time.Hour,
+	}))
+	elapsed := time.Since(started)
+
+	var incompatible *RuntimeIncompatibleError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("initialize() error = %v (%T), want *RuntimeIncompatibleError", err, err)
+	}
+	if incompatible.Reason != RuntimeIncompatibleReasonMajorMismatch {
+		t.Fatalf("Reason = %q", incompatible.Reason)
+	}
+	if incompatible.ClientProtocolVersion != stagehandProtocolVersion ||
+		incompatible.ExtensionProtocolVersion != incompatibleMajorProtocolVersion(t) ||
+		incompatible.ServerInfo != (ImplementationInfo{Name: stagehandRuntimeName, Version: "9.9.9"}) {
+		t.Fatalf("error fields = %#v", incompatible)
+	}
+	if !strings.Contains(err.Error(), runtimeIncompatibleRemediation) {
+		t.Fatalf("Error() = %q, missing remediation hint", err.Error())
+	}
+	if got := polls.Load(); got != 1 {
+		t.Fatalf("Runtime.evaluate polls = %d, want exactly 1", got)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("initialize() took %s, expected fail-fast", elapsed)
+	}
+}
+
+func TestCDPClientFailsFastOnWrongRuntimeName(t *testing.T) {
+	t.Parallel()
+
+	socket := newFakeCDPWebSocket()
+	responder, polls := loadedExtensionResponder(func(int) map[string]any {
+		return runtimeMarkerResponse(map[string]any{
+			"protocolVersion": stagehandProtocolVersion,
+			"serverInfo":      map[string]any{"name": "other-runtime", "version": "1.2.3"},
+		}, true)
+	})
+	socket.writeHook = responseHook(t, socket, nil, responder)
+	client := newTestCDPClient(t, socket, "ws://127.0.0.1/devtools/browser/test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.initialize(ctx, normalizeCDPClientOptions(cdpClientOptions{
+		extensionDir: "/tmp/stagehand-extension",
+		pollInterval: time.Hour,
+	}))
+
+	var incompatible *RuntimeIncompatibleError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("initialize() error = %v (%T), want *RuntimeIncompatibleError", err, err)
+	}
+	if incompatible.Reason != RuntimeIncompatibleReasonRuntimeNameMismatch {
+		t.Fatalf("Reason = %q", incompatible.Reason)
+	}
+	if incompatible.ServerInfo != (ImplementationInfo{Name: "other-runtime", Version: "1.2.3"}) {
+		t.Fatalf("ServerInfo = %#v", incompatible.ServerInfo)
+	}
+	if got := polls.Load(); got != 1 {
+		t.Fatalf("Runtime.evaluate polls = %d, want exactly 1", got)
+	}
+}
+
+func TestCDPClientKeepsPollingUnknownRuntimeUntilCompatible(t *testing.T) {
+	t.Parallel()
+
+	socket := newFakeCDPWebSocket()
+	responder, polls := loadedExtensionResponder(func(poll int) map[string]any {
+		switch poll {
+		case 1:
+			return runtimeMarkerResponse(nil, false)
+		case 2:
+			return runtimeExceptionResponse()
+		case 3:
+			return runtimeMarkerResponse(compatibleRuntimeMarker(), false)
+		default:
+			return runtimeMarkerResponse(compatibleRuntimeMarker(), true)
+		}
+	})
+	socket.writeHook = responseHook(t, socket, nil, responder)
+	client := newTestCDPClient(t, socket, "ws://127.0.0.1/devtools/browser/test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.initialize(ctx, normalizeCDPClientOptions(cdpClientOptions{
+		extensionDir: "/tmp/stagehand-extension",
+		pollInterval: time.Millisecond,
+	}))
+	if err != nil {
+		t.Fatalf("initialize() error = %v", err)
+	}
+	if got := polls.Load(); got != 4 {
+		t.Fatalf("Runtime.evaluate polls = %d, want 4", got)
+	}
+}
+
+func TestCDPClientAllowFallbackInstallKeepsPollingIncompatibleRuntime(t *testing.T) {
+	t.Parallel()
+
+	socket := newFakeCDPWebSocket()
+	responder, polls := loadedExtensionResponder(func(poll int) map[string]any {
+		if poll <= 2 {
+			return runtimeMarkerResponse(incompatibleRuntimeMarker(t), true)
+		}
+		return runtimeMarkerResponse(compatibleRuntimeMarker(), true)
+	})
+	socket.writeHook = responseHook(t, socket, nil, responder)
+	client := newTestCDPClient(t, socket, "ws://127.0.0.1/devtools/browser/test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.initialize(ctx, normalizeCDPClientOptions(cdpClientOptions{
+		extensionDir:         "/tmp/stagehand-extension",
+		pollInterval:         time.Millisecond,
+		allowFallbackInstall: true,
+	}))
+	if err != nil {
+		t.Fatalf("initialize() error = %v", err)
+	}
+	if got := polls.Load(); got != 3 {
+		t.Fatalf("Runtime.evaluate polls = %d, want 3", got)
+	}
+}
+
+func TestCDPClientPreloadedExtensionFailsFastOnIncompatibleRuntime(t *testing.T) {
+	t.Parallel()
+
+	socket := newFakeCDPWebSocket()
+	methods := make(chan string, 64)
+	var polls atomic.Int32
+	socket.writeHook = responseHook(t, socket, methods, func(
+		method string,
+		_ map[string]json.RawMessage,
+	) map[string]any {
+		switch method {
+		case "Target.getTargets":
+			return map[string]any{"result": map[string]any{
+				"targetInfos": []map[string]any{{
+					"targetId": "worker-target",
+					"type":     "service_worker",
+					"title":    "Stagehand",
+					"url":      "chrome-extension://preloaded-extension/service-worker.js",
+				}},
+			}}
+		case "Target.attachToTarget":
+			return map[string]any{"result": map[string]any{"sessionId": "worker-session"}}
+		case "Runtime.evaluate":
+			polls.Add(1)
+			return runtimeMarkerResponse(incompatibleRuntimeMarker(t), true)
+		default:
+			return map[string]any{"result": map[string]any{}}
+		}
+	})
+	client := newTestCDPClient(t, socket, "ws://127.0.0.1/devtools/browser/test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.initialize(ctx, normalizeCDPClientOptions(cdpClientOptions{
+		preloadedExtension: true,
+		pollInterval:       time.Hour,
+	}))
+
+	var incompatible *RuntimeIncompatibleError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("initialize() error = %v (%T), want *RuntimeIncompatibleError", err, err)
+	}
+	if incompatible.Reason != RuntimeIncompatibleReasonMajorMismatch {
+		t.Fatalf("Reason = %q", incompatible.Reason)
+	}
+	if got := polls.Load(); got != 1 {
+		t.Fatalf("Runtime.evaluate polls = %d, want exactly 1", got)
+	}
+	actualMethods := drainMethods(methods)
+	expectedMethods := []string{
+		"Target.getTargets",
+		"Target.attachToTarget",
+		"Runtime.evaluate",
+		"Target.detachFromTarget",
+	}
+	if !reflect.DeepEqual(actualMethods, expectedMethods) {
+		t.Fatalf("CDP methods = %#v, want %#v", actualMethods, expectedMethods)
+	}
+}

--- a/packages/sdk-go/cdp_client_test.go
+++ b/packages/sdk-go/cdp_client_test.go
@@ -1100,6 +1100,9 @@ func TestCDPClientFailsFastOnIncompatibleRuntime(t *testing.T) {
 		extensionDir: "/tmp/stagehand-extension",
 		pollInterval: time.Hour,
 	}))
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("initialize() kept polling an incompatible runtime instead of failing fast")
+	}
 	elapsed := time.Since(started)
 
 	var incompatible *RuntimeIncompatibleError
@@ -1144,6 +1147,9 @@ func TestCDPClientFailsFastOnWrongRuntimeName(t *testing.T) {
 		extensionDir: "/tmp/stagehand-extension",
 		pollInterval: time.Hour,
 	}))
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("initialize() kept polling an incompatible runtime instead of failing fast")
+	}
 
 	var incompatible *RuntimeIncompatibleError
 	if !errors.As(err, &incompatible) {
@@ -1344,6 +1350,9 @@ func TestCDPClientPreloadedExtensionFailsFastOnIncompatibleRuntime(t *testing.T)
 		preloadedExtension: true,
 		pollInterval:       time.Hour,
 	}))
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("initialize() kept polling an incompatible runtime instead of failing fast")
+	}
 
 	var incompatible *RuntimeIncompatibleError
 	if !errors.As(err, &incompatible) {

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -133,11 +133,25 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeCompatibility {
 		}
 	}
 
+	// Mirrors the protocol's ImplementationInfoSchema: both fields are non-empty
+	// strings. A marker missing either is malformed, not a foreign runtime, so
+	// keep polling.
 	var serverInfo ImplementationInfo
 	if err := json.Unmarshal(marker["serverInfo"], &serverInfo); err != nil {
 		return runtimeCompatibility{
 			Kind:   runtimeCompatibilityUnknown,
 			Detail: "unreadable Stagehand runtime marker: serverInfo.name=<nil>",
+		}
+	}
+	if serverInfo.Name == "" || serverInfo.Version == "" {
+		return runtimeCompatibility{
+			Kind: runtimeCompatibilityUnknown,
+			Detail: fmt.Sprintf(
+				"unreadable Stagehand runtime marker: serverInfo.name=%q serverInfo.version=%q",
+				serverInfo.Name,
+				serverInfo.Version,
+			),
+			ServerInfo: serverInfo,
 		}
 	}
 
@@ -153,27 +167,11 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeCompatibility {
 		}
 	}
 
-	// Mirrors the TypeScript schema: every field must be a non-empty string before
-	// the marker is judged. A null serverInfo or an empty name/version is a marker
-	// shape this client cannot read yet, not a verdict.
-	if serverInfo.Name == "" || serverInfo.Version == "" || protocolVersion == "" {
-		return runtimeCompatibility{
-			Kind: runtimeCompatibilityUnknown,
-			Detail: fmt.Sprintf(
-				"unreadable Stagehand runtime marker: serverInfo.name=%q serverInfo.version=%q protocolVersion=%q",
-				serverInfo.Name,
-				serverInfo.Version,
-				protocolVersion,
-			),
-			ServerInfo: serverInfo,
-		}
-	}
-
 	if serverInfo.Name != stagehandRuntimeName {
 		return runtimeCompatibility{
 			Kind:                    runtimeCompatibilityIncompatible,
 			Reason:                  RuntimeIncompatibleReasonRuntimeNameMismatch,
-			Detail:                  fmt.Sprintf("Runtime name mismatch: expected %q, server reported %q", stagehandRuntimeName, serverInfo.Name),
+			Detail:                  fmt.Sprintf("Connected runtime is not Stagehand: serverInfo.name=%q", serverInfo.Name),
 			ReportedProtocolVersion: protocolVersion,
 			ServerInfo:              serverInfo,
 		}

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -14,75 +14,223 @@ const (
 	stagehandSDKClientName = "stagehand-sdk-go"
 )
 
+// Reasons carried by RuntimeIncompatibleError.Reason. They mirror the
+// TypeScript and Python clients so cross-SDK diagnostics line up.
+const (
+	RuntimeIncompatibleReasonInvalidVersion      = "protocol-invalid-version"
+	RuntimeIncompatibleReasonMajorMismatch       = "protocol-major-mismatch"
+	RuntimeIncompatibleReasonServerTooOld        = "protocol-server-too-old"
+	RuntimeIncompatibleReasonPrereleaseMismatch  = "protocol-prerelease-mismatch"
+	RuntimeIncompatibleReasonRuntimeNameMismatch = "runtime-name-mismatch"
+)
+
+// runtimeIncompatibleRemediation is the one-line hint appended to every
+// RuntimeIncompatibleError message.
+const runtimeIncompatibleRemediation = "Upgrade the Stagehand SDK and the " +
+	"Stagehand extension together so their protocol majors match, or start " +
+	"the session with the extension bundled in this SDK."
+
+// RuntimeIncompatibleError is returned when the connected Stagehand extension
+// publishes a runtime marker that this SDK cannot talk to: the protocol major
+// differs, the extension is older than the SDK requires, a prerelease does not
+// match exactly, or the marker was published by a different runtime.
+//
+// The client fails fast instead of polling until the initialization timeout;
+// callers can detect it with errors.As.
+type RuntimeIncompatibleError struct {
+	// Reason is one of the RuntimeIncompatibleReason* constants.
+	Reason string
+	// Detail is the human-readable negotiation outcome.
+	Detail string
+	// ClientProtocolVersion is the protocol version this SDK speaks.
+	ClientProtocolVersion string
+	// ExtensionProtocolVersion is the protocol version the extension reported.
+	ExtensionProtocolVersion string
+	// ServerInfo is the extension's reported serverInfo (name and version).
+	ServerInfo ImplementationInfo
+}
+
+func (err *RuntimeIncompatibleError) Error() string {
+	return fmt.Sprintf(
+		"Incompatible Stagehand runtime (%s): %s; client protocol %s, extension protocol %s, extension %s/%s. %s",
+		err.Reason,
+		err.Detail,
+		err.ClientProtocolVersion,
+		err.ExtensionProtocolVersion,
+		err.ServerInfo.Name,
+		err.ServerInfo.Version,
+		runtimeIncompatibleRemediation,
+	)
+}
+
+// runtimeCompatibilityKind is the three-way outcome of reading the runtime
+// marker: compatible, definitively incompatible, or not (yet) decidable.
+type runtimeCompatibilityKind int
+
+const (
+	// runtimeCompatibilityUnknown means the marker is absent, not yet set, or
+	// unreadable. Callers should keep polling.
+	runtimeCompatibilityUnknown runtimeCompatibilityKind = iota
+	// runtimeCompatibilityIncompatible means the marker parsed but the
+	// protocol rules (or runtime name) reject it. Polling cannot fix this.
+	runtimeCompatibilityIncompatible
+	// runtimeCompatibilityCompatible means the extension can be used.
+	runtimeCompatibilityCompatible
+)
+
+func (kind runtimeCompatibilityKind) String() string {
+	switch kind {
+	case runtimeCompatibilityCompatible:
+		return "compatible"
+	case runtimeCompatibilityIncompatible:
+		return "incompatible"
+	default:
+		return "unknown"
+	}
+}
+
+type runtimeCompatibility struct {
+	Kind   runtimeCompatibilityKind
+	Reason string
+	Detail string
+	// Reported fields are populated whenever the marker parsed, i.e. for
+	// compatible and incompatible outcomes.
+	ReportedProtocolVersion string
+	ServerInfo              ImplementationInfo
+}
+
+// incompatibleError converts an incompatible negotiation into the exported
+// error type. It returns nil for any other kind.
+func (compat runtimeCompatibility) incompatibleError() *RuntimeIncompatibleError {
+	if compat.Kind != runtimeCompatibilityIncompatible {
+		return nil
+	}
+	return &RuntimeIncompatibleError{
+		Reason:                   compat.Reason,
+		Detail:                   compat.Detail,
+		ClientProtocolVersion:    stagehandProtocolVersion,
+		ExtensionProtocolVersion: compat.ReportedProtocolVersion,
+		ServerInfo:               compat.ServerInfo,
+	}
+}
+
 // negotiateRuntimeCompatibility deliberately mirrors the TypeScript and
 // Python clients. The runtime marker is transport state, while ServerInfo
 // reuses the protocol-generated ImplementationInfo struct.
-func negotiateRuntimeCompatibility(raw json.RawMessage) (bool, string) {
+func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeCompatibility {
 	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
-		return false, "no Stagehand runtime marker"
+		return runtimeCompatibility{
+			Kind:   runtimeCompatibilityUnknown,
+			Detail: "no Stagehand runtime marker",
+		}
 	}
 
 	var marker map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &marker); err != nil {
-		return false, "unreadable Stagehand runtime marker"
+		return runtimeCompatibility{
+			Kind:   runtimeCompatibilityUnknown,
+			Detail: "unreadable Stagehand runtime marker",
+		}
 	}
 
 	var serverInfo ImplementationInfo
 	if err := json.Unmarshal(marker["serverInfo"], &serverInfo); err != nil {
-		return false, "serverInfo.name=<nil>"
-	}
-	if serverInfo.Name != stagehandRuntimeName {
-		return false, fmt.Sprintf("serverInfo.name=%q", serverInfo.Name)
+		return runtimeCompatibility{
+			Kind:   runtimeCompatibilityUnknown,
+			Detail: "unreadable Stagehand runtime marker: serverInfo.name=<nil>",
+		}
 	}
 
 	var protocolVersion string
 	if err := json.Unmarshal(marker["protocolVersion"], &protocolVersion); err != nil {
-		return false, fmt.Sprintf(
-			"protocolVersion=%s",
-			rawJSONDescription(marker["protocolVersion"]),
-		)
+		return runtimeCompatibility{
+			Kind: runtimeCompatibilityUnknown,
+			Detail: fmt.Sprintf(
+				"unreadable Stagehand runtime marker: protocolVersion=%s",
+				rawJSONDescription(marker["protocolVersion"]),
+			),
+			ServerInfo: serverInfo,
+		}
 	}
-	return protocolCompatibility(stagehandProtocolVersion, protocolVersion)
+
+	if serverInfo.Name != stagehandRuntimeName {
+		return runtimeCompatibility{
+			Kind:                    runtimeCompatibilityIncompatible,
+			Reason:                  RuntimeIncompatibleReasonRuntimeNameMismatch,
+			Detail:                  fmt.Sprintf("serverInfo.name=%q is not %q", serverInfo.Name, stagehandRuntimeName),
+			ReportedProtocolVersion: protocolVersion,
+			ServerInfo:              serverInfo,
+		}
+	}
+
+	compat := protocolCompatibility(stagehandProtocolVersion, protocolVersion)
+	compat.ReportedProtocolVersion = protocolVersion
+	compat.ServerInfo = serverInfo
+	return compat
 }
 
-func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) (bool, string) {
+func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) runtimeCompatibility {
+	incompatible := func(reason, detail string) runtimeCompatibility {
+		return runtimeCompatibility{
+			Kind:   runtimeCompatibilityIncompatible,
+			Reason: reason,
+			Detail: detail,
+		}
+	}
+	compatible := runtimeCompatibility{
+		Kind:   runtimeCompatibilityCompatible,
+		Detail: fmt.Sprintf("protocolVersion=%s", serverProtocolVersion),
+	}
+
 	clientVersion := "v" + clientProtocolVersion
 	serverVersion := "v" + serverProtocolVersion
 	if !validProtocolVersion(clientProtocolVersion) || !validProtocolVersion(serverProtocolVersion) {
-		return false, fmt.Sprintf(
-			"invalid protocol version: client=%q server=%q",
-			clientProtocolVersion,
-			serverProtocolVersion,
+		return incompatible(
+			RuntimeIncompatibleReasonInvalidVersion,
+			fmt.Sprintf(
+				"invalid protocol version: client=%q server=%q",
+				clientProtocolVersion,
+				serverProtocolVersion,
+			),
 		)
 	}
 	if semver.Prerelease(clientVersion) != "" || semver.Prerelease(serverVersion) != "" {
 		if serverProtocolVersion != clientProtocolVersion {
-			return false, fmt.Sprintf(
-				"protocol prereleases must match exactly: client=%s server=%s",
-				clientProtocolVersion,
-				serverProtocolVersion,
+			return incompatible(
+				RuntimeIncompatibleReasonPrereleaseMismatch,
+				fmt.Sprintf(
+					"protocol prereleases must match exactly: client=%s server=%s",
+					clientProtocolVersion,
+					serverProtocolVersion,
+				),
 			)
 		}
-		return true, fmt.Sprintf("protocolVersion=%s", serverProtocolVersion)
+		return compatible
 	}
 	if semver.Major(clientVersion) != semver.Major(serverVersion) {
-		return false, fmt.Sprintf(
-			"protocol major mismatch: client=%s server=%s",
-			clientProtocolVersion,
-			serverProtocolVersion,
+		return incompatible(
+			RuntimeIncompatibleReasonMajorMismatch,
+			fmt.Sprintf(
+				"protocol major mismatch: client=%s server=%s",
+				clientProtocolVersion,
+				serverProtocolVersion,
+			),
 		)
 	}
 	clientMinor := semver.MajorMinor(clientVersion) + ".0"
 	serverMinor := semver.MajorMinor(serverVersion) + ".0"
 	if semver.Compare(serverMinor, clientMinor) < 0 {
-		return false, fmt.Sprintf(
-			"server protocol %s is older than client requirement %s",
-			serverProtocolVersion,
-			clientProtocolVersion,
+		return incompatible(
+			RuntimeIncompatibleReasonServerTooOld,
+			fmt.Sprintf(
+				"server protocol %s is older than client requirement %s",
+				serverProtocolVersion,
+				clientProtocolVersion,
+			),
 		)
 	}
 
-	return true, fmt.Sprintf("protocolVersion=%s", serverProtocolVersion)
+	return compatible
 }
 
 func validProtocolVersion(version string) bool {

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -156,7 +156,7 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeCompatibility {
 	}
 
 	var protocolVersion string
-	if err := json.Unmarshal(marker["protocolVersion"], &protocolVersion); err != nil {
+	if err := json.Unmarshal(marker["protocolVersion"], &protocolVersion); err != nil || protocolVersion == "" {
 		return runtimeCompatibility{
 			Kind: runtimeCompatibilityUnknown,
 			Detail: fmt.Sprintf(
@@ -171,7 +171,7 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeCompatibility {
 		return runtimeCompatibility{
 			Kind:                    runtimeCompatibilityIncompatible,
 			Reason:                  RuntimeIncompatibleReasonRuntimeNameMismatch,
-			Detail:                  fmt.Sprintf("Connected runtime is not Stagehand: serverInfo.name=%q", serverInfo.Name),
+			Detail:                  fmt.Sprintf("Runtime name mismatch: expected %q, server reported %q", stagehandRuntimeName, serverInfo.Name),
 			ReportedProtocolVersion: protocolVersion,
 			ServerInfo:              serverInfo,
 		}

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -153,11 +153,27 @@ func negotiateRuntimeCompatibility(raw json.RawMessage) runtimeCompatibility {
 		}
 	}
 
+	// Mirrors the TypeScript schema: every field must be a non-empty string before
+	// the marker is judged. A null serverInfo or an empty name/version is a marker
+	// shape this client cannot read yet, not a verdict.
+	if serverInfo.Name == "" || serverInfo.Version == "" || protocolVersion == "" {
+		return runtimeCompatibility{
+			Kind: runtimeCompatibilityUnknown,
+			Detail: fmt.Sprintf(
+				"unreadable Stagehand runtime marker: serverInfo.name=%q serverInfo.version=%q protocolVersion=%q",
+				serverInfo.Name,
+				serverInfo.Version,
+				protocolVersion,
+			),
+			ServerInfo: serverInfo,
+		}
+	}
+
 	if serverInfo.Name != stagehandRuntimeName {
 		return runtimeCompatibility{
 			Kind:                    runtimeCompatibilityIncompatible,
 			Reason:                  RuntimeIncompatibleReasonRuntimeNameMismatch,
-			Detail:                  fmt.Sprintf("serverInfo.name=%q is not %q", serverInfo.Name, stagehandRuntimeName),
+			Detail:                  fmt.Sprintf("Runtime name mismatch: expected %q, server reported %q", stagehandRuntimeName, serverInfo.Name),
 			ReportedProtocolVersion: protocolVersion,
 			ServerInfo:              serverInfo,
 		}
@@ -188,7 +204,7 @@ func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) 
 		return incompatible(
 			RuntimeIncompatibleReasonInvalidVersion,
 			fmt.Sprintf(
-				"invalid protocol version: client=%q server=%q",
+				"Invalid protocol version: client %s, server %s",
 				clientProtocolVersion,
 				serverProtocolVersion,
 			),
@@ -199,7 +215,7 @@ func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) 
 			return incompatible(
 				RuntimeIncompatibleReasonPrereleaseMismatch,
 				fmt.Sprintf(
-					"protocol prereleases must match exactly: client=%s server=%s",
+					"Protocol prereleases must match exactly: client %s, server %s",
 					clientProtocolVersion,
 					serverProtocolVersion,
 				),
@@ -211,7 +227,7 @@ func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) 
 		return incompatible(
 			RuntimeIncompatibleReasonMajorMismatch,
 			fmt.Sprintf(
-				"protocol major mismatch: client=%s server=%s",
+				"Protocol major mismatch: client %s, server %s",
 				clientProtocolVersion,
 				serverProtocolVersion,
 			),
@@ -223,7 +239,7 @@ func protocolCompatibility(clientProtocolVersion, serverProtocolVersion string) 
 		return incompatible(
 			RuntimeIncompatibleReasonServerTooOld,
 			fmt.Sprintf(
-				"server protocol %s is older than client requirement %s",
+				"Server protocol %s is older than client requirement %s",
 				serverProtocolVersion,
 				clientProtocolVersion,
 			),

--- a/packages/sdk-go/runtime_compatibility_test.go
+++ b/packages/sdk-go/runtime_compatibility_test.go
@@ -86,7 +86,7 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			marker: runtimeMarkerJSON(stagehandProtocolVersion, "other"),
 			kind:   runtimeCompatibilityIncompatible,
 			reason: RuntimeIncompatibleReasonRuntimeNameMismatch,
-			detail: `Connected runtime is not Stagehand: serverInfo.name="other"`,
+			detail: `Runtime name mismatch: expected "stagehand", server reported "other"`,
 		},
 		{
 			name:   "non-semver protocol version",
@@ -136,6 +136,12 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `", "serverInfo": {"name": "stagehand", "version": 1}}`,
 			kind:   runtimeCompatibilityUnknown,
 			detail: "serverInfo.name=<nil>",
+		},
+		{
+			name:   "empty protocol version",
+			marker: `{"protocolVersion": "", "serverInfo": {"name": "stagehand", "version": "1.0.0"}}`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: "protocolVersion=",
 		},
 	}
 

--- a/packages/sdk-go/runtime_compatibility_test.go
+++ b/packages/sdk-go/runtime_compatibility_test.go
@@ -86,20 +86,56 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			marker: runtimeMarkerJSON(stagehandProtocolVersion, "other"),
 			kind:   runtimeCompatibilityIncompatible,
 			reason: RuntimeIncompatibleReasonRuntimeNameMismatch,
-			detail: `serverInfo.name="other"`,
+			detail: `Runtime name mismatch: expected "stagehand", server reported "other"`,
 		},
 		{
 			name:   "non-semver protocol version",
 			marker: runtimeMarkerJSON("not-semver", stagehandRuntimeName),
 			kind:   runtimeCompatibilityIncompatible,
 			reason: RuntimeIncompatibleReasonInvalidVersion,
-			detail: "invalid protocol version",
+			detail: "Invalid protocol version: client " + stagehandProtocolVersion + ", server not-semver",
 		},
 		{
 			name:   "non-string protocol version",
 			marker: runtimeMarkerJSON(1, stagehandRuntimeName),
 			kind:   runtimeCompatibilityUnknown,
 			detail: "protocolVersion=1",
+		},
+		{
+			name:   "empty protocol version",
+			marker: runtimeMarkerJSON("", stagehandRuntimeName),
+			kind:   runtimeCompatibilityUnknown,
+			detail: `protocolVersion=""`,
+		},
+		{
+			name:   "null serverInfo",
+			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `", "serverInfo": null}`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: `serverInfo.name=""`,
+		},
+		{
+			name:   "empty serverInfo name",
+			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `", "serverInfo": {"name": "", "version": "1.0.0"}}`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: `serverInfo.name=""`,
+		},
+		{
+			name:   "empty serverInfo version",
+			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `", "serverInfo": {"name": "stagehand", "version": ""}}`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: `serverInfo.version=""`,
+		},
+		{
+			name:   "missing serverInfo version",
+			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `", "serverInfo": {"name": "stagehand"}}`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: `serverInfo.version=""`,
+		},
+		{
+			name:   "non-string serverInfo version",
+			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `", "serverInfo": {"name": "stagehand", "version": 1}}`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: "serverInfo.name=<nil>",
 		},
 	}
 
@@ -177,12 +213,13 @@ func TestProtocolCompatibility(t *testing.T) {
 	}{
 		{name: "patch ignored", client: "1.2.4", server: "1.2.0", kind: runtimeCompatibilityCompatible},
 		{name: "newer server minor", client: "1.2.4", server: "1.9.0", kind: runtimeCompatibilityCompatible},
-		{name: "server too old", client: "1.2.4", server: "1.1.99", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonServerTooOld, detail: "older"},
-		{name: "major mismatch", client: "1.2.4", server: "2.0.0", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonMajorMismatch, detail: "major mismatch"},
+		// Detail wording is shared verbatim with the TypeScript and Python SDKs.
+		{name: "server too old", client: "1.2.4", server: "1.1.99", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonServerTooOld, detail: "Server protocol 1.1.99 is older than client requirement 1.2.4"},
+		{name: "major mismatch", client: "1.2.4", server: "2.0.0", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonMajorMismatch, detail: "Protocol major mismatch: client 1.2.4, server 2.0.0"},
 		{name: "exact prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.1", kind: runtimeCompatibilityCompatible},
-		{name: "different prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.2", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonPrereleaseMismatch, detail: "match exactly"},
-		{name: "invalid client", client: "not-semver", server: "1.3.0", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonInvalidVersion, detail: "invalid protocol version"},
-		{name: "invalid server", client: "1.3.0", server: "not-semver", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonInvalidVersion, detail: "invalid protocol version"},
+		{name: "different prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.2", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonPrereleaseMismatch, detail: "Protocol prereleases must match exactly: client 1.3.0-beta.1, server 1.3.0-beta.2"},
+		{name: "invalid client", client: "not-semver", server: "1.3.0", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonInvalidVersion, detail: "Invalid protocol version: client not-semver, server 1.3.0"},
+		{name: "invalid server", client: "1.3.0", server: "not-semver", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonInvalidVersion, detail: "Invalid protocol version: client 1.3.0, server not-semver"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/packages/sdk-go/runtime_compatibility_test.go
+++ b/packages/sdk-go/runtime_compatibility_test.go
@@ -86,7 +86,7 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			marker: runtimeMarkerJSON(stagehandProtocolVersion, "other"),
 			kind:   runtimeCompatibilityIncompatible,
 			reason: RuntimeIncompatibleReasonRuntimeNameMismatch,
-			detail: `Runtime name mismatch: expected "stagehand", server reported "other"`,
+			detail: `Connected runtime is not Stagehand: serverInfo.name="other"`,
 		},
 		{
 			name:   "non-semver protocol version",
@@ -102,16 +102,16 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 			detail: "protocolVersion=1",
 		},
 		{
-			name:   "empty protocol version",
-			marker: runtimeMarkerJSON("", stagehandRuntimeName),
-			kind:   runtimeCompatibilityUnknown,
-			detail: `protocolVersion=""`,
-		},
-		{
 			name:   "null serverInfo",
 			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `", "serverInfo": null}`,
 			kind:   runtimeCompatibilityUnknown,
 			detail: `serverInfo.name=""`,
+		},
+		{
+			name:   "non-object serverInfo",
+			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `", "serverInfo": "stagehand"}`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: "serverInfo.name=<nil>",
 		},
 		{
 			name:   "empty serverInfo name",

--- a/packages/sdk-go/runtime_compatibility_test.go
+++ b/packages/sdk-go/runtime_compatibility_test.go
@@ -2,60 +2,104 @@ package stagehand
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
+
+	"golang.org/x/mod/semver"
 )
+
+// incompatibleMajorProtocolVersion derives a protocol version whose major is
+// one above the SDK's current protocol so tests never hardcode a version that
+// silently becomes compatible after a protocol bump.
+func incompatibleMajorProtocolVersion(t *testing.T) string {
+	t.Helper()
+	major := strings.TrimPrefix(semver.Major("v"+stagehandProtocolVersion), "v")
+	value, err := strconv.Atoi(major)
+	if err != nil {
+		t.Fatalf("parse protocol major from %q: %v", stagehandProtocolVersion, err)
+	}
+	return fmt.Sprintf("%d.0.0", value+1)
+}
+
+func runtimeMarkerJSON(protocolVersion any, serverName string) string {
+	encoded, _ := json.Marshal(map[string]any{
+		"protocolVersion": protocolVersion,
+		"serverInfo":      map[string]any{"name": serverName, "version": "1.0.0"},
+	})
+	return string(encoded)
+}
 
 func TestNegotiateRuntimeCompatibility(t *testing.T) {
 	t.Parallel()
 
+	incompatibleMajor := incompatibleMajorProtocolVersion(t)
+
 	tests := []struct {
-		name       string
-		marker     string
-		compatible bool
-		detail     string
+		name   string
+		marker string
+		kind   runtimeCompatibilityKind
+		reason string
+		detail string
 	}{
 		{
-			name: "compatible",
-			marker: `{
-				"protocolVersion": "1.0.9",
-				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
-			}`,
-			compatible: true,
-			detail:     "protocolVersion=1.0.9",
+			name:   "compatible",
+			marker: runtimeMarkerJSON(stagehandProtocolVersion, stagehandRuntimeName),
+			kind:   runtimeCompatibilityCompatible,
+			detail: "protocolVersion=" + stagehandProtocolVersion,
 		},
 		{
-			name:       "missing marker",
-			marker:     `null`,
-			compatible: false,
-			detail:     "no Stagehand runtime marker",
+			name:   "missing marker",
+			marker: `null`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: "no Stagehand runtime marker",
 		},
 		{
-			name: "major mismatch",
-			marker: `{
-				"protocolVersion": "2.0.0",
-				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
-			}`,
-			compatible: false,
-			detail:     "major mismatch",
+			name:   "empty marker",
+			marker: ``,
+			kind:   runtimeCompatibilityUnknown,
+			detail: "no Stagehand runtime marker",
 		},
 		{
-			name: "wrong runtime",
-			marker: `{
-				"protocolVersion": "1.0.0",
-				"serverInfo": {"name": "other", "version": "1.0.0"}
-			}`,
-			compatible: false,
-			detail:     `serverInfo.name="other"`,
+			name:   "unreadable marker",
+			marker: `"not an object"`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: "unreadable Stagehand runtime marker",
 		},
 		{
-			name: "invalid protocol version",
-			marker: `{
-				"protocolVersion": 1,
-				"serverInfo": {"name": "stagehand", "version": "1.0.0"}
-			}`,
-			compatible: false,
-			detail:     "protocolVersion=1",
+			name:   "missing serverInfo",
+			marker: `{"protocolVersion": "` + stagehandProtocolVersion + `"}`,
+			kind:   runtimeCompatibilityUnknown,
+			detail: "serverInfo.name=<nil>",
+		},
+		{
+			name:   "major mismatch",
+			marker: runtimeMarkerJSON(incompatibleMajor, stagehandRuntimeName),
+			kind:   runtimeCompatibilityIncompatible,
+			reason: RuntimeIncompatibleReasonMajorMismatch,
+			detail: "major mismatch",
+		},
+		{
+			name:   "wrong runtime",
+			marker: runtimeMarkerJSON(stagehandProtocolVersion, "other"),
+			kind:   runtimeCompatibilityIncompatible,
+			reason: RuntimeIncompatibleReasonRuntimeNameMismatch,
+			detail: `serverInfo.name="other"`,
+		},
+		{
+			name:   "non-semver protocol version",
+			marker: runtimeMarkerJSON("not-semver", stagehandRuntimeName),
+			kind:   runtimeCompatibilityIncompatible,
+			reason: RuntimeIncompatibleReasonInvalidVersion,
+			detail: "invalid protocol version",
+		},
+		{
+			name:   "non-string protocol version",
+			marker: runtimeMarkerJSON(1, stagehandRuntimeName),
+			kind:   runtimeCompatibilityUnknown,
+			detail: "protocolVersion=1",
 		},
 	}
 
@@ -63,16 +107,60 @@ func TestNegotiateRuntimeCompatibility(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			compatible, detail := negotiateRuntimeCompatibility(
-				json.RawMessage(test.marker),
-			)
-			if compatible != test.compatible {
-				t.Fatalf("compatible = %t, want %t", compatible, test.compatible)
+			compat := negotiateRuntimeCompatibility(json.RawMessage(test.marker))
+			if compat.Kind != test.kind {
+				t.Fatalf("kind = %s, want %s (detail %q)", compat.Kind, test.kind, compat.Detail)
 			}
-			if !strings.Contains(detail, test.detail) {
-				t.Fatalf("detail = %q, want it to contain %q", detail, test.detail)
+			if compat.Reason != test.reason {
+				t.Fatalf("reason = %q, want %q", compat.Reason, test.reason)
+			}
+			if !strings.Contains(compat.Detail, test.detail) {
+				t.Fatalf("detail = %q, want it to contain %q", compat.Detail, test.detail)
+			}
+			err := compat.incompatibleError()
+			if (err != nil) != (test.kind == runtimeCompatibilityIncompatible) {
+				t.Fatalf("incompatibleError() = %v for kind %s", err, compat.Kind)
 			}
 		})
+	}
+}
+
+func TestRuntimeIncompatibleErrorCarriesNegotiationFields(t *testing.T) {
+	t.Parallel()
+
+	incompatibleMajor := incompatibleMajorProtocolVersion(t)
+	compat := negotiateRuntimeCompatibility(json.RawMessage(
+		`{"protocolVersion": "` + incompatibleMajor + `", "serverInfo": {"name": "stagehand", "version": "9.9.9"}}`,
+	))
+	var err error = compat.incompatibleError()
+
+	var incompatible *RuntimeIncompatibleError
+	if !errors.As(err, &incompatible) {
+		t.Fatalf("errors.As(*RuntimeIncompatibleError) failed for %T", err)
+	}
+	if incompatible.Reason != RuntimeIncompatibleReasonMajorMismatch {
+		t.Fatalf("Reason = %q", incompatible.Reason)
+	}
+	if incompatible.ClientProtocolVersion != stagehandProtocolVersion {
+		t.Fatalf("ClientProtocolVersion = %q", incompatible.ClientProtocolVersion)
+	}
+	if incompatible.ExtensionProtocolVersion != incompatibleMajor {
+		t.Fatalf("ExtensionProtocolVersion = %q", incompatible.ExtensionProtocolVersion)
+	}
+	if incompatible.ServerInfo != (ImplementationInfo{Name: "stagehand", Version: "9.9.9"}) {
+		t.Fatalf("ServerInfo = %#v", incompatible.ServerInfo)
+	}
+	message := err.Error()
+	for _, want := range []string{
+		"Incompatible Stagehand runtime (protocol-major-mismatch)",
+		"client protocol " + stagehandProtocolVersion,
+		"extension protocol " + incompatibleMajor,
+		"extension stagehand/9.9.9",
+		runtimeIncompatibleRemediation,
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("Error() = %q, want it to contain %q", message, want)
+		}
 	}
 }
 
@@ -80,29 +168,33 @@ func TestProtocolCompatibility(t *testing.T) {
 	t.Parallel()
 
 	for _, test := range []struct {
-		name       string
-		client     string
-		server     string
-		compatible bool
-		detail     string
+		name   string
+		client string
+		server string
+		kind   runtimeCompatibilityKind
+		reason string
+		detail string
 	}{
-		{name: "patch ignored", client: "1.2.4", server: "1.2.0", compatible: true},
-		{name: "newer server minor", client: "1.2.4", server: "1.9.0", compatible: true},
-		{name: "server too old", client: "1.2.4", server: "1.1.99", detail: "older"},
-		{name: "major mismatch", client: "1.2.4", server: "2.0.0", detail: "major mismatch"},
-		{name: "exact prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.1", compatible: true},
-		{name: "different prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.2", detail: "match exactly"},
-		{name: "invalid client", client: "not-semver", server: "1.3.0", detail: "invalid protocol version"},
-		{name: "invalid server", client: "1.3.0", server: "not-semver", detail: "invalid protocol version"},
+		{name: "patch ignored", client: "1.2.4", server: "1.2.0", kind: runtimeCompatibilityCompatible},
+		{name: "newer server minor", client: "1.2.4", server: "1.9.0", kind: runtimeCompatibilityCompatible},
+		{name: "server too old", client: "1.2.4", server: "1.1.99", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonServerTooOld, detail: "older"},
+		{name: "major mismatch", client: "1.2.4", server: "2.0.0", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonMajorMismatch, detail: "major mismatch"},
+		{name: "exact prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.1", kind: runtimeCompatibilityCompatible},
+		{name: "different prerelease", client: "1.3.0-beta.1", server: "1.3.0-beta.2", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonPrereleaseMismatch, detail: "match exactly"},
+		{name: "invalid client", client: "not-semver", server: "1.3.0", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonInvalidVersion, detail: "invalid protocol version"},
+		{name: "invalid server", client: "1.3.0", server: "not-semver", kind: runtimeCompatibilityIncompatible, reason: RuntimeIncompatibleReasonInvalidVersion, detail: "invalid protocol version"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			compatible, detail := protocolCompatibility(test.client, test.server)
-			if compatible != test.compatible {
-				t.Fatalf("compatible = %t, want %t", compatible, test.compatible)
+			compat := protocolCompatibility(test.client, test.server)
+			if compat.Kind != test.kind {
+				t.Fatalf("kind = %s, want %s", compat.Kind, test.kind)
 			}
-			if !strings.Contains(detail, test.detail) {
-				t.Fatalf("detail = %q, want it to contain %q", detail, test.detail)
+			if compat.Reason != test.reason {
+				t.Fatalf("reason = %q, want %q", compat.Reason, test.reason)
+			}
+			if !strings.Contains(compat.Detail, test.detail) {
+				t.Fatalf("detail = %q, want it to contain %q", compat.Detail, test.detail)
 			}
 		})
 	}

--- a/packages/sdk-python/src/stagehand/__init__.py
+++ b/packages/sdk-python/src/stagehand/__init__.py
@@ -58,6 +58,7 @@ from ._generated.models import (
 from .browser import StagehandBrowser, browserbase, local_browser
 from .browser_clipboard import BrowserClipboard
 from .browser_context import BrowserContext
+from .cdp_client import StagehandRuntimeIncompatibleError
 from .client_models import (
     DefaultExtract,
     ExtractResult,
@@ -141,6 +142,7 @@ __all__ = [
     "StagehandClientLoggingConfig",
     "StagehandMetrics",
     "StagehandResultMetadata",
+    "StagehandRuntimeIncompatibleError",
     "State",
     "TelemetryConfig",
     "Variables",

--- a/packages/sdk-python/src/stagehand/cdp_client.py
+++ b/packages/sdk-python/src/stagehand/cdp_client.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol, cast
+from typing import Any, Literal, Protocol, TypeGuard, cast
 from urllib.request import urlopen
 
 from stagehand._generated.protocol_version import (
@@ -132,23 +132,27 @@ def _negotiate_runtime(marker: object) -> RuntimeCompatibility:
     name = server_info.get("name") if isinstance(server_info, Mapping) else None
     version = server_info.get("version") if isinstance(server_info, Mapping) else None
     protocol_version = marker.get("protocolVersion")
-    if not isinstance(name, str) or not isinstance(protocol_version, str):
-        # Not a marker shape this client can read: the worker may still be publishing it.
+    # Mirrors the TypeScript schema: every field must be a non-empty string before the marker
+    # is judged. Anything else is a marker shape this client cannot read yet, not a verdict.
+    if not (
+        _non_empty_string(name)
+        and _non_empty_string(version)
+        and _non_empty_string(protocol_version)
+    ):
         return RuntimeCompatibility(
             kind="unknown",
             detail=f"unreadable runtime marker: serverInfo.name={name!r} "
-            f"protocolVersion={protocol_version!r}",
+            f"serverInfo.version={version!r} protocolVersion={protocol_version!r}",
         )
-    server_version = version if isinstance(version, str) else None
 
     if name != _RUNTIME_NAME:
         return RuntimeCompatibility(
             kind="incompatible",
             reason="runtime-name-mismatch",
-            detail=f"runtime name mismatch: expected {_RUNTIME_NAME!r}, serverInfo.name={name!r}",
+            detail=f'Runtime name mismatch: expected "{_RUNTIME_NAME}", server reported "{name}"',
             protocol_version=protocol_version,
             server_name=name,
-            server_version=server_version,
+            server_version=version,
         )
 
     mismatch = _protocol_compatibility(STAGEHAND_PROTOCOL_VERSION, protocol_version)
@@ -160,7 +164,7 @@ def _negotiate_runtime(marker: object) -> RuntimeCompatibility:
             detail=detail,
             protocol_version=protocol_version,
             server_name=name,
-            server_version=server_version,
+            server_version=version,
         )
 
     return RuntimeCompatibility(
@@ -168,8 +172,12 @@ def _negotiate_runtime(marker: object) -> RuntimeCompatibility:
         detail=f"protocolVersion={protocol_version}",
         protocol_version=protocol_version,
         server_name=name,
-        server_version=server_version,
+        server_version=version,
     )
+
+
+def _non_empty_string(value: object) -> TypeGuard[str]:
+    return isinstance(value, str) and value != ""
 
 
 def _protocol_compatibility(
@@ -181,25 +189,25 @@ def _protocol_compatibility(
     if client is None or server is None:
         return (
             "protocol-invalid-version",
-            f"invalid protocol version: client={client_version!r} server={server_version!r}",
+            f"Invalid protocol version: client {client_version}, server {server_version}",
         )
     if client.group(4) is not None or server.group(4) is not None:
         if client_version != server_version:
             return (
                 "protocol-prerelease-mismatch",
-                "protocol prereleases must match exactly: "
-                f"client={client_version} server={server_version}",
+                "Protocol prereleases must match exactly: "
+                f"client {client_version}, server {server_version}",
             )
         return None
     if client.group(1) != server.group(1):
         return (
             "protocol-major-mismatch",
-            f"protocol major mismatch: client={client_version} server={server_version}",
+            f"Protocol major mismatch: client {client_version}, server {server_version}",
         )
     if int(server.group(2)) < int(client.group(2)):
         return (
             "protocol-server-too-old",
-            f"server protocol {server_version} is older than client requirement {client_version}",
+            f"Server protocol {server_version} is older than client requirement {client_version}",
         )
     return None
 
@@ -566,12 +574,15 @@ class CDPClient:
         """Return a discovered worker and its flat CDP session, left attached for the caller.
 
         Each candidate must be attached to evaluate readiness; unready candidates are detached
-        before the next poll. A sweep that finds no compatible worker but at least one
+        before the next poll. A sweep that finds no compatible marker but at least one
         incompatible one raises ``StagehandRuntimeIncompatibleError`` immediately unless
         ``allow_fallback_install`` is True (reserved for a future preloaded-extension flow).
         """
         while True:
             incompatible: RuntimeCompatibility | None = None
+            # A compatible worker whose receiver is not installed yet must keep the sweep
+            # polling even when a sibling worker is incompatible.
+            saw_compatible_marker = False
             response = await self.send_command("Target.getTargets")
             targets = response.get("targetInfos")
             target_infos = cast(list[object], targets) if isinstance(targets, list) else []
@@ -616,6 +627,8 @@ class CDPClient:
                             compatibility = _negotiate_runtime(value.get("marker"))
                             if compatibility.kind == "incompatible" and not allow_fallback_install:
                                 incompatible = compatibility
+                            if compatibility.compatible:
+                                saw_compatible_marker = True
                             if compatibility.compatible and value.get("hasReceiver") is True:
                                 service_worker = ServiceWorkerInfo(
                                     target_id=_required_string(
@@ -639,9 +652,9 @@ class CDPClient:
                                 "Target.detachFromTarget",
                                 {"sessionId": session_id},
                             )
-            # No compatible worker in this sweep and at least one incompatible one: fail fast
+            # No compatible marker in this sweep and at least one incompatible one: fail fast
             # instead of re-polling until the initialization deadline.
-            if incompatible is not None:
+            if incompatible is not None and not saw_compatible_marker:
                 raise StagehandRuntimeIncompatibleError(incompatible)
             await asyncio.sleep(0.1)
 

--- a/packages/sdk-python/src/stagehand/cdp_client.py
+++ b/packages/sdk-python/src/stagehand/cdp_client.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 from urllib.request import urlopen
 
 from stagehand._generated.protocol_version import (
@@ -58,42 +58,149 @@ def _callback_source_from_message(message: dict[str, object]) -> str | None:
     return source
 
 
-def _negotiate_runtime(marker: object) -> tuple[bool, str]:
-    """Return (compatible, detail). Never raises: a malformed marker is just incompatible."""
+RuntimeIncompatibilityReason = Literal[
+    "protocol-invalid-version",
+    "protocol-major-mismatch",
+    "protocol-server-too-old",
+    "protocol-prerelease-mismatch",
+    "runtime-name-mismatch",
+]
+
+RUNTIME_INCOMPATIBILITY_REMEDIATION = (
+    "Upgrade the Stagehand SDK and the Stagehand extension together so their protocol majors "
+    "match, or start the session with the extension bundled in this SDK."
+)
+
+
+@dataclass(frozen=True)
+class RuntimeCompatibility:
+    """Outcome of negotiating against the extension's `globalThis.__stagehand_runtime` marker.
+
+    - ``compatible``: the marker parses and satisfies the protocol rules.
+    - ``incompatible``: the marker parses but the protocol rules reject it, or it names a
+      foreign runtime. Callers fail fast on this instead of re-polling.
+    - ``unknown``: the marker is absent, not yet set, or unreadable. Callers keep polling.
+    """
+
+    kind: Literal["compatible", "incompatible", "unknown"]
+    detail: str
+    reason: RuntimeIncompatibilityReason | None = None
+    protocol_version: str | None = None
+    server_name: str | None = None
+    server_version: str | None = None
+
+    @property
+    def compatible(self) -> bool:
+        return self.kind == "compatible"
+
+
+class StagehandRuntimeIncompatibleError(RuntimeError):
+    """Raised as soon as the connected Stagehand extension reports a runtime this SDK cannot use.
+
+    Covers a protocol major mismatch, an extension older than the client requirement, a
+    prerelease mismatch, an invalid protocol version, or a foreign runtime name.
+    """
+
+    def __init__(self, compatibility: RuntimeCompatibility) -> None:
+        if compatibility.kind != "incompatible" or compatibility.reason is None:
+            raise ValueError("StagehandRuntimeIncompatibleError requires an incompatible result")
+        self.compatibility = compatibility
+        self.reason: RuntimeIncompatibilityReason = compatibility.reason
+        self.detail = compatibility.detail
+        self.client_protocol_version = STAGEHAND_PROTOCOL_VERSION
+        self.extension_protocol_version = compatibility.protocol_version
+        self.extension_server_info = {
+            "name": compatibility.server_name,
+            "version": compatibility.server_version,
+        }
+        self.remediation = RUNTIME_INCOMPATIBILITY_REMEDIATION
+        super().__init__(
+            f"Incompatible Stagehand runtime ({self.reason}): {self.detail}; "
+            f"client protocol {self.client_protocol_version}, "
+            f"extension protocol {self.extension_protocol_version}, "
+            f"extension {compatibility.server_name}/{compatibility.server_version}. "
+            f"{RUNTIME_INCOMPATIBILITY_REMEDIATION}"
+        )
+
+
+def _negotiate_runtime(marker: object) -> RuntimeCompatibility:
+    """Classify a runtime marker. Never raises: a malformed marker is ``unknown``."""
     if not isinstance(marker, Mapping):
-        return False, "no Stagehand runtime marker"
+        return RuntimeCompatibility(kind="unknown", detail="no Stagehand runtime marker")
 
     server_info = marker.get("serverInfo")
     name = server_info.get("name") if isinstance(server_info, Mapping) else None
-    if name != _RUNTIME_NAME:
-        return False, f"serverInfo.name={name!r}"
-
+    version = server_info.get("version") if isinstance(server_info, Mapping) else None
     protocol_version = marker.get("protocolVersion")
-    if not isinstance(protocol_version, str):
-        return False, f"protocolVersion={protocol_version!r}"
-    compatibility = _protocol_compatibility(STAGEHAND_PROTOCOL_VERSION, protocol_version)
-    if compatibility is not None:
-        return False, compatibility
+    if not isinstance(name, str) or not isinstance(protocol_version, str):
+        # Not a marker shape this client can read: the worker may still be publishing it.
+        return RuntimeCompatibility(
+            kind="unknown",
+            detail=f"unreadable runtime marker: serverInfo.name={name!r} "
+            f"protocolVersion={protocol_version!r}",
+        )
+    server_version = version if isinstance(version, str) else None
 
-    return True, f"protocolVersion={protocol_version}"
+    if name != _RUNTIME_NAME:
+        return RuntimeCompatibility(
+            kind="incompatible",
+            reason="runtime-name-mismatch",
+            detail=f"runtime name mismatch: expected {_RUNTIME_NAME!r}, serverInfo.name={name!r}",
+            protocol_version=protocol_version,
+            server_name=name,
+            server_version=server_version,
+        )
+
+    mismatch = _protocol_compatibility(STAGEHAND_PROTOCOL_VERSION, protocol_version)
+    if mismatch is not None:
+        reason, detail = mismatch
+        return RuntimeCompatibility(
+            kind="incompatible",
+            reason=reason,
+            detail=detail,
+            protocol_version=protocol_version,
+            server_name=name,
+            server_version=server_version,
+        )
+
+    return RuntimeCompatibility(
+        kind="compatible",
+        detail=f"protocolVersion={protocol_version}",
+        protocol_version=protocol_version,
+        server_name=name,
+        server_version=server_version,
+    )
 
 
-def _protocol_compatibility(client_version: str, server_version: str) -> str | None:
+def _protocol_compatibility(
+    client_version: str, server_version: str
+) -> tuple[RuntimeIncompatibilityReason, str] | None:
+    """Return ``(reason, detail)`` when the versions are incompatible, else ``None``."""
     client = _PROTOCOL_SEMVER_PATTERN.fullmatch(client_version)
     server = _PROTOCOL_SEMVER_PATTERN.fullmatch(server_version)
     if client is None or server is None:
-        return f"invalid protocol version: client={client_version!r} server={server_version!r}"
+        return (
+            "protocol-invalid-version",
+            f"invalid protocol version: client={client_version!r} server={server_version!r}",
+        )
     if client.group(4) is not None or server.group(4) is not None:
         if client_version != server_version:
             return (
+                "protocol-prerelease-mismatch",
                 "protocol prereleases must match exactly: "
-                f"client={client_version} server={server_version}"
+                f"client={client_version} server={server_version}",
             )
         return None
     if client.group(1) != server.group(1):
-        return f"protocol major mismatch: client={client_version} server={server_version}"
+        return (
+            "protocol-major-mismatch",
+            f"protocol major mismatch: client={client_version} server={server_version}",
+        )
     if int(server.group(2)) < int(client.group(2)):
-        return f"server protocol {server_version} is older than client requirement {client_version}"
+        return (
+            "protocol-server-too-old",
+            f"server protocol {server_version} is older than client requirement {client_version}",
+        )
     return None
 
 
@@ -453,13 +560,18 @@ class CDPClient:
     async def _wait_for_preloaded_service_worker(
         self,
         url_includes: str,
+        *,
+        allow_fallback_install: bool = False,
     ) -> tuple[ServiceWorkerInfo, str]:
         """Return a discovered worker and its flat CDP session, left attached for the caller.
 
-        Each candidate must be attached to evaluate readiness; unready or incompatible
-        candidates are detached before the next poll.
+        Each candidate must be attached to evaluate readiness; unready candidates are detached
+        before the next poll. A sweep that finds no compatible worker but at least one
+        incompatible one raises ``StagehandRuntimeIncompatibleError`` immediately unless
+        ``allow_fallback_install`` is True (reserved for a future preloaded-extension flow).
         """
         while True:
+            incompatible: RuntimeCompatibility | None = None
             response = await self.send_command("Target.getTargets")
             targets = response.get("targetInfos")
             target_infos = cast(list[object], targets) if isinstance(targets, list) else []
@@ -501,8 +613,10 @@ class CDPClient:
                         result = evaluated.get("result")
                         value = result.get("value") if isinstance(result, Mapping) else None
                         if isinstance(value, Mapping):
-                            compatible, _ = _negotiate_runtime(value.get("marker"))
-                            if compatible and value.get("hasReceiver") is True:
+                            compatibility = _negotiate_runtime(value.get("marker"))
+                            if compatibility.kind == "incompatible" and not allow_fallback_install:
+                                incompatible = compatibility
+                            if compatibility.compatible and value.get("hasReceiver") is True:
                                 service_worker = ServiceWorkerInfo(
                                     target_id=_required_string(
                                         target_info, "targetId", "Target.getTargets"
@@ -525,9 +639,18 @@ class CDPClient:
                                 "Target.detachFromTarget",
                                 {"sessionId": session_id},
                             )
+            # No compatible worker in this sweep and at least one incompatible one: fail fast
+            # instead of re-polling until the initialization deadline.
+            if incompatible is not None:
+                raise StagehandRuntimeIncompatibleError(incompatible)
             await asyncio.sleep(0.1)
 
-    async def _wait_for_runtime_receiver(self, session_id: str) -> None:
+    async def _wait_for_runtime_receiver(
+        self,
+        session_id: str,
+        *,
+        allow_fallback_install: bool = False,
+    ) -> None:
         while True:
             try:
                 evaluated = await self.send_command(
@@ -544,9 +667,15 @@ class CDPClient:
                     value = result.get("value") if isinstance(result, Mapping) else None
                     if isinstance(value, Mapping):
                         has_receiver = value.get("hasReceiver") is True
-                        compatible, _ = _negotiate_runtime(value.get("marker"))
-                        if compatible and has_receiver:
+                        compatibility = _negotiate_runtime(value.get("marker"))
+                        # Fail fast by default; allow_fallback_install is reserved for a future
+                        # Browserbase preloaded-extension flow that may replace the runtime.
+                        if compatibility.kind == "incompatible" and not allow_fallback_install:
+                            raise StagehandRuntimeIncompatibleError(compatibility)
+                        if compatibility.compatible and has_receiver:
                             return
+            except StagehandRuntimeIncompatibleError:
+                raise
             except Exception:
                 pass
             await asyncio.sleep(0.1)

--- a/packages/sdk-python/src/stagehand/cdp_client.py
+++ b/packages/sdk-python/src/stagehand/cdp_client.py
@@ -132,24 +132,26 @@ def _negotiate_runtime(marker: object) -> RuntimeCompatibility:
     name = server_info.get("name") if isinstance(server_info, Mapping) else None
     version = server_info.get("version") if isinstance(server_info, Mapping) else None
     protocol_version = marker.get("protocolVersion")
-    # Mirrors the TypeScript schema: every field must be a non-empty string before the marker
-    # is judged. Anything else is a marker shape this client cannot read yet, not a verdict.
-    if not (
-        _non_empty_string(name)
-        and _non_empty_string(version)
-        and _non_empty_string(protocol_version)
-    ):
+    # Mirrors the protocol's ImplementationInfoSchema: both fields are non-empty strings.
+    # A marker missing either is malformed, not a foreign runtime, so keep polling.
+    if not _non_empty_string(name) or not _non_empty_string(version):
         return RuntimeCompatibility(
             kind="unknown",
             detail=f"unreadable runtime marker: serverInfo.name={name!r} "
-            f"serverInfo.version={version!r} protocolVersion={protocol_version!r}",
+            f"serverInfo.version={version!r}",
+        )
+    if not isinstance(protocol_version, str):
+        # Not a marker shape this client can read: the worker may still be publishing it.
+        return RuntimeCompatibility(
+            kind="unknown",
+            detail=f"unreadable runtime marker: protocolVersion={protocol_version!r}",
         )
 
     if name != _RUNTIME_NAME:
         return RuntimeCompatibility(
             kind="incompatible",
             reason="runtime-name-mismatch",
-            detail=f'Runtime name mismatch: expected "{_RUNTIME_NAME}", server reported "{name}"',
+            detail=f"Connected runtime is not Stagehand: serverInfo.name={json.dumps(name)}",
             protocol_version=protocol_version,
             server_name=name,
             server_version=version,

--- a/packages/sdk-python/src/stagehand/cdp_client.py
+++ b/packages/sdk-python/src/stagehand/cdp_client.py
@@ -140,7 +140,7 @@ def _negotiate_runtime(marker: object) -> RuntimeCompatibility:
             detail=f"unreadable runtime marker: serverInfo.name={name!r} "
             f"serverInfo.version={version!r}",
         )
-    if not isinstance(protocol_version, str):
+    if not isinstance(protocol_version, str) or not protocol_version:
         # Not a marker shape this client can read: the worker may still be publishing it.
         return RuntimeCompatibility(
             kind="unknown",
@@ -151,7 +151,7 @@ def _negotiate_runtime(marker: object) -> RuntimeCompatibility:
         return RuntimeCompatibility(
             kind="incompatible",
             reason="runtime-name-mismatch",
-            detail=f"Connected runtime is not Stagehand: serverInfo.name={json.dumps(name)}",
+            detail=f'Runtime name mismatch: expected "{_RUNTIME_NAME}", server reported "{name}"',
             protocol_version=protocol_version,
             server_name=name,
             server_version=version,

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -1180,8 +1180,11 @@ class TestNegotiateRuntime:
                 "serverInfo.name=''",
             ),
             (
-                {"protocolVersion": "", "serverInfo": {"name": "stagehand", "version": "1.0.0"}},
-                "protocolVersion=''",
+                {
+                    "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
+                    "serverInfo": {"name": 1, "version": "1.0.0"},
+                },
+                "serverInfo.name=1",
             ),
         ],
     )
@@ -1221,7 +1224,7 @@ class TestNegotiateRuntime:
                     "serverInfo": {"name": "other", "version": "1"},
                 },
                 "runtime-name-mismatch",
-                'Runtime name mismatch: expected "stagehand", server reported "other"',
+                'Connected runtime is not Stagehand: serverInfo.name="other"',
             ),
             (
                 {
@@ -1261,6 +1264,7 @@ class TestNegotiateRuntime:
             {"serverInfo": "not-a-mapping"},
             {"serverInfo": None},
             {"protocolVersion": "1.0.0", "serverInfo": {"name": "", "version": ""}},
+            {"protocolVersion": "1.0.0", "serverInfo": {"name": "stagehand"}},
         ):
             assert cdp_client._negotiate_runtime(marker).kind == "unknown"
 

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -12,7 +12,17 @@ from stagehand.cdp_client import (
     STAGEHAND_SEND_TO_HOST_BINDING,
     CDPClient,
     ServiceWorkerInfo,
+    StagehandRuntimeIncompatibleError,
 )
+
+
+def _bump_major(version: str) -> str:
+    """A protocol version one major ahead of the client's: incompatible by definition."""
+    major, rest = version.split(".", 1)
+    return f"{int(major) + 1}.{rest}"
+
+
+INCOMPATIBLE_PROTOCOL_VERSION = _bump_major(STAGEHAND_PROTOCOL_VERSION)
 
 
 def _ready_marker() -> dict[str, object]:
@@ -25,6 +35,23 @@ def _ready_marker() -> dict[str, object]:
         },
         "hasReceiver": True,
     }
+
+
+def _incompatible_marker() -> dict[str, object]:
+    """A ready worker speaking a protocol major this client cannot use."""
+    return {
+        "marker": {
+            "protocolVersion": INCOMPATIBLE_PROTOCOL_VERSION,
+            "serverInfo": {"name": "stagehand", "version": "9.0.0"},
+            "state": "ready",
+        },
+        "hasReceiver": True,
+    }
+
+
+def _unknown_marker() -> dict[str, object]:
+    """A worker that has not published its runtime marker yet."""
+    return {"marker": None, "hasReceiver": False}
 
 
 def test_callback_batch_source_allows_native_code_text() -> None:
@@ -574,9 +601,13 @@ async def test_preloaded_discovery_detaches_stale_worker_then_accepts_ready_work
         await client.close()
 
 
-async def test_preloaded_discovery_detaches_incompatible_worker_then_accepts_ready_worker(
+async def test_preloaded_discovery_fails_fast_on_a_foreign_runtime_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A worker naming a foreign runtime is incompatible: detach it and raise on the first sweep.
+
+    Before fail-fast this test expected discovery to keep polling and accept a later ready worker.
+    """
     get_targets_calls = 0
 
     def response_for(message: dict[str, object]) -> dict[str, object]:
@@ -622,16 +653,112 @@ async def test_preloaded_discovery_detaches_incompatible_worker_then_accepts_rea
 
     monkeypatch.setattr(cdp_client, "_resolve_browser_web_socket_url", resolve)
     monkeypatch.setattr(cdp_client, "_connect_web_socket", connect)
-    client = await CDPClient.connect(
-        cdp_url="wss://browserbase",
-        preloaded_extension=True,
-    )
+    with pytest.raises(StagehandRuntimeIncompatibleError) as raised:
+        await CDPClient.connect(
+            cdp_url="wss://browserbase",
+            preloaded_extension=True,
+        )
+    assert raised.value.reason == "runtime-name-mismatch"
+    assert raised.value.extension_server_info == {"name": "foreign-extension", "version": "1.0.0"}
+    assert get_targets_calls == 1
+    detach = [message for message in socket.sent if message["method"] == "Target.detachFromTarget"]
+    assert cast(dict[str, object], detach[0]["params"])["sessionId"] == "foreign-session"
+    assert socket.closed is True
+
+
+async def test_preloaded_discovery_fails_fast_on_an_incompatible_protocol_major(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    def response_for(message: dict[str, object]) -> dict[str, object]:
+        method = message["method"]
+        if method == "Target.getTargets":
+            return {
+                "result": {
+                    "targetInfos": [
+                        {
+                            "targetId": "worker-target",
+                            "type": "service_worker",
+                            "title": "Stagehand",
+                            "url": "chrome-extension://preloaded/service-worker.js",
+                        }
+                    ]
+                }
+            }
+        if method == "Target.attachToTarget":
+            return {"result": {"sessionId": "worker-session"}}
+        if method == "Runtime.evaluate":
+            return {"result": {"result": {"value": _incompatible_marker()}}}
+        return {"result": {}}
+
+    socket = FakeWebSocket(response_for)
+
+    async def resolve(_: str) -> str:
+        return "ws://127.0.0.1/devtools/browser/test"
+
+    async def connect(_: str) -> FakeWebSocket:
+        return socket
+
+    monkeypatch.setattr(cdp_client, "_resolve_browser_web_socket_url", resolve)
+    monkeypatch.setattr(cdp_client, "_connect_web_socket", connect)
+    monkeypatch.setattr(cdp_client.asyncio, "sleep", record_sleep)
+    with pytest.raises(StagehandRuntimeIncompatibleError) as raised:
+        await CDPClient.connect(
+            cdp_url="wss://browserbase",
+            preloaded_extension=True,
+        )
+    assert raised.value.reason == "protocol-major-mismatch"
+    assert raised.value.extension_protocol_version == INCOMPATIBLE_PROTOCOL_VERSION
+    assert sleeps == [], "the incompatible marker must raise before any second poll"
+    evaluates = [message for message in socket.sent if message["method"] == "Runtime.evaluate"]
+    assert len(evaluates) == 1
+
+
+async def test_preloaded_discovery_keeps_polling_when_fallback_install_is_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    evaluate_calls = 0
+
+    def response_for(message: dict[str, object]) -> dict[str, object]:
+        nonlocal evaluate_calls
+        method = message["method"]
+        if method == "Target.getTargets":
+            return {
+                "result": {
+                    "targetInfos": [
+                        {
+                            "targetId": "worker-target",
+                            "type": "service_worker",
+                            "title": "Stagehand",
+                            "url": "chrome-extension://preloaded/service-worker.js",
+                        }
+                    ]
+                }
+            }
+        if method == "Target.attachToTarget":
+            return {"result": {"sessionId": "worker-session"}}
+        if method == "Runtime.evaluate":
+            evaluate_calls += 1
+            value = _incompatible_marker() if evaluate_calls < 3 else _ready_marker()
+            return {"result": {"result": {"value": value}}}
+        return {"result": {}}
+
+    socket = FakeWebSocket(response_for)
+    client = CDPClient(socket, "ws://127.0.0.1/devtools/browser/test")
     try:
-        assert client.service_worker.target_id == "ready"
-        detach = [
-            message for message in socket.sent if message["method"] == "Target.detachFromTarget"
-        ]
-        assert cast(dict[str, object], detach[0]["params"])["sessionId"] == "foreign-session"
+        worker, session_id = await asyncio.wait_for(
+            client._wait_for_preloaded_service_worker(
+                "service-worker.js", allow_fallback_install=True
+            ),
+            timeout=5,
+        )
+        assert worker.target_id == "worker-target"
+        assert session_id == "worker-session"
+        assert evaluate_calls == 3
     finally:
         await client.close()
 
@@ -783,6 +910,132 @@ async def test_preloaded_discovery_remains_open_until_the_caller_cancels(
     assert socket.closed is True
 
 
+def _receiver_client(
+    values: list[dict[str, object] | None],
+) -> tuple[CDPClient, FakeWebSocket, list[dict[str, object]]]:
+    """A client whose Runtime.evaluate replies walk `values`; None yields exceptionDetails."""
+    evaluates: list[dict[str, object]] = []
+
+    def response_for(message: dict[str, object]) -> dict[str, object]:
+        if message["method"] != "Runtime.evaluate":
+            return {"result": {}}
+        evaluates.append(message)
+        value = values[min(len(evaluates), len(values)) - 1]
+        if value is None:
+            return {"result": {"exceptionDetails": {"text": "not ready"}}}
+        return {"result": {"result": {"value": value}}}
+
+    socket = FakeWebSocket(response_for)
+    return CDPClient(socket, "ws://127.0.0.1/devtools/browser/test"), socket, evaluates
+
+
+async def test_runtime_receiver_fails_fast_on_the_first_incompatible_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(cdp_client.asyncio, "sleep", record_sleep)
+    client, _, evaluates = _receiver_client([_incompatible_marker()])
+    try:
+        with pytest.raises(StagehandRuntimeIncompatibleError) as raised:
+            await client._wait_for_runtime_receiver("worker-session")
+    finally:
+        await client.close()
+
+    error = raised.value
+    assert error.reason == "protocol-major-mismatch"
+    assert error.client_protocol_version == STAGEHAND_PROTOCOL_VERSION
+    assert error.extension_protocol_version == INCOMPATIBLE_PROTOCOL_VERSION
+    assert error.extension_server_info == {"name": "stagehand", "version": "9.0.0"}
+    assert error.remediation == cdp_client.RUNTIME_INCOMPATIBILITY_REMEDIATION
+    message = str(error)
+    assert message.startswith("Incompatible Stagehand runtime (protocol-major-mismatch): ")
+    assert f"client protocol {STAGEHAND_PROTOCOL_VERSION}" in message
+    assert f"extension protocol {INCOMPATIBLE_PROTOCOL_VERSION}" in message
+    assert "extension stagehand/9.0.0" in message
+    assert message.endswith(cdp_client.RUNTIME_INCOMPATIBILITY_REMEDIATION)
+    assert len(evaluates) == 1
+    assert sleeps == [], "the incompatible marker must raise before any second poll"
+
+
+async def test_runtime_receiver_fails_fast_on_a_wrong_runtime_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_sleep(_: float) -> None:
+        raise AssertionError("must not poll again after an incompatible marker")
+
+    monkeypatch.setattr(cdp_client.asyncio, "sleep", no_sleep)
+    foreign = _ready_marker()
+    foreign["marker"] = {
+        "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
+        "serverInfo": {"name": "other-runtime", "version": "3.1.4"},
+    }
+    client, _, evaluates = _receiver_client([foreign])
+    try:
+        with pytest.raises(StagehandRuntimeIncompatibleError) as raised:
+            await client._wait_for_runtime_receiver("worker-session")
+    finally:
+        await client.close()
+    assert raised.value.reason == "runtime-name-mismatch"
+    assert raised.value.extension_server_info == {"name": "other-runtime", "version": "3.1.4"}
+    assert len(evaluates) == 1
+
+
+async def test_runtime_receiver_keeps_polling_through_unknown_markers_until_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(cdp_client.asyncio, "sleep", record_sleep)
+    client, _, evaluates = _receiver_client([
+        None,  # Runtime.evaluate exceptionDetails: the worker is still booting
+        _unknown_marker(),
+        _unknown_marker(),
+        _ready_marker(),
+    ])
+    try:
+        await asyncio.wait_for(client._wait_for_runtime_receiver("worker-session"), timeout=5)
+    finally:
+        await client.close()
+    assert len(evaluates) == 4
+    assert sleeps == [0.1, 0.1, 0.1]
+
+
+async def test_runtime_receiver_keeps_polling_on_incompatible_when_fallback_install_is_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(cdp_client.asyncio, "sleep", no_sleep)
+    client, _, evaluates = _receiver_client([
+        _incompatible_marker(),
+        _incompatible_marker(),
+        _ready_marker(),
+    ])
+    try:
+        await asyncio.wait_for(
+            client._wait_for_runtime_receiver("worker-session", allow_fallback_install=True),
+            timeout=5,
+        )
+    finally:
+        await client.close()
+    assert len(evaluates) == 3
+
+
+def test_runtime_incompatible_error_is_exported_from_the_package() -> None:
+    import stagehand
+
+    assert stagehand.StagehandRuntimeIncompatibleError is StagehandRuntimeIncompatibleError
+    assert "StagehandRuntimeIncompatibleError" in stagehand.__all__
+
+
 class TestNegotiateRuntime:
     """Mirrors the TypeScript negotiation tests so the two SDKs cannot drift apart.
 
@@ -792,21 +1045,22 @@ class TestNegotiateRuntime:
     """
 
     def test_accepts_a_current_marker(self) -> None:
-        compatible, detail = cdp_client._negotiate_runtime({
+        result = cdp_client._negotiate_runtime({
             "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
             "serverInfo": {"name": "stagehand", "version": "1.0.0"},
         })
-        assert compatible is True
-        assert f"protocolVersion={STAGEHAND_PROTOCOL_VERSION}" in detail
+        assert result.kind == "compatible"
+        assert result.compatible is True
+        assert f"protocolVersion={STAGEHAND_PROTOCOL_VERSION}" in result.detail
 
     def test_tolerates_unknown_extra_keys(self) -> None:
         # A newer runtime may publish fields this client has never heard of, e.g. `status`.
-        compatible, _ = cdp_client._negotiate_runtime({
+        result = cdp_client._negotiate_runtime({
             "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
             "serverInfo": {"name": "stagehand", "version": "1.0.0"},
             "status": {"state": "ready"},
         })
-        assert compatible is True
+        assert result.kind == "compatible"
 
     @pytest.mark.parametrize(
         ("marker", "expected"),
@@ -815,9 +1069,34 @@ class TestNegotiateRuntime:
             ({}, "serverInfo.name=None"),
             (
                 {
-                    "protocolVersion": "2.0.0",
+                    "protocolVersion": 1,
+                    "serverInfo": {"name": "stagehand", "version": "1"},
+                },
+                "protocolVersion=1",
+            ),
+            ("string", "no Stagehand runtime marker"),
+            ({"serverInfo": "not-a-mapping"}, "unreadable"),
+        ],
+    )
+    def test_unreadable_markers_are_unknown_not_incompatible(
+        self, marker: object, expected: str
+    ) -> None:
+        """Absent or unparseable markers mean "not ready yet": the wait loops keep polling."""
+        result = cdp_client._negotiate_runtime(marker)
+        assert result.kind == "unknown"
+        assert result.compatible is False
+        assert result.reason is None
+        assert expected in result.detail
+
+    @pytest.mark.parametrize(
+        ("marker", "reason", "expected"),
+        [
+            (
+                {
+                    "protocolVersion": INCOMPATIBLE_PROTOCOL_VERSION,
                     "serverInfo": {"name": "stagehand", "version": "0"},
                 },
+                "protocol-major-mismatch",
                 "major mismatch",
             ),
             (
@@ -825,6 +1104,7 @@ class TestNegotiateRuntime:
                     "protocolVersion": "not-semver",
                     "serverInfo": {"name": "stagehand", "version": "2"},
                 },
+                "protocol-invalid-version",
                 "invalid protocol version",
             ),
             (
@@ -832,32 +1112,63 @@ class TestNegotiateRuntime:
                     "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
                     "serverInfo": {"name": "other", "version": "1"},
                 },
-                "name=",
+                "runtime-name-mismatch",
+                "serverInfo.name='other'",
             ),
             (
                 {
-                    "protocolVersion": 1,
+                    "protocolVersion": f"{STAGEHAND_PROTOCOL_VERSION}-beta.1",
                     "serverInfo": {"name": "stagehand", "version": "1"},
                 },
-                "protocolVersion=1",
+                "protocol-prerelease-mismatch",
+                "match exactly",
             ),
         ],
     )
-    def test_rejects_unusable_markers(self, marker: object, expected: str) -> None:
-        compatible, detail = cdp_client._negotiate_runtime(marker)
-        assert compatible is False
-        assert expected in detail
+    def test_rejected_markers_are_incompatible(
+        self, marker: dict[str, object], reason: str, expected: str
+    ) -> None:
+        """Markers that parse but fail negotiation are incompatible: the wait loops fail fast."""
+        result = cdp_client._negotiate_runtime(marker)
+        assert result.kind == "incompatible"
+        assert result.compatible is False
+        assert result.reason == reason
+        assert expected in result.detail
+        assert result.protocol_version == marker["protocolVersion"]
+        server_info = cast(dict[str, object], marker["serverInfo"])
+        assert result.server_name == server_info["name"]
+        assert result.server_version == server_info["version"]
+        error = StagehandRuntimeIncompatibleError(result)
+        assert error.reason == reason
+        assert error.client_protocol_version == STAGEHAND_PROTOCOL_VERSION
 
     def test_never_raises_on_hostile_input(self) -> None:
         for marker in ("string", 42, [], {"serverInfo": "not-a-mapping"}, {"serverInfo": None}):
-            assert cdp_client._negotiate_runtime(marker)[0] is False
+            assert cdp_client._negotiate_runtime(marker).kind == "unknown"
+
+    def test_incompatible_error_rejects_non_incompatible_results(self) -> None:
+        with pytest.raises(ValueError):
+            StagehandRuntimeIncompatibleError(
+                cdp_client.RuntimeCompatibility(kind="unknown", detail="no marker")
+            )
 
     def test_protocol_semver_directionality(self) -> None:
         assert cdp_client._protocol_compatibility("1.2.4", "1.2.0") is None
         assert cdp_client._protocol_compatibility("1.2.4", "1.9.0") is None
-        assert "older" in (cdp_client._protocol_compatibility("1.2.4", "1.1.99") or "")
-        assert "major mismatch" in (cdp_client._protocol_compatibility("1.2.4", "2.0.0") or "")
+        assert cdp_client._protocol_compatibility("1.2.4", "1.1.99") == (
+            "protocol-server-too-old",
+            "server protocol 1.1.99 is older than client requirement 1.2.4",
+        )
+        assert cdp_client._protocol_compatibility("1.2.4", "2.0.0") == (
+            "protocol-major-mismatch",
+            "protocol major mismatch: client=1.2.4 server=2.0.0",
+        )
         assert cdp_client._protocol_compatibility("1.3.0-beta.1", "1.3.0-beta.1") is None
-        assert "match exactly" in (
-            cdp_client._protocol_compatibility("1.3.0-beta.1", "1.3.0-beta.2") or ""
+        assert cdp_client._protocol_compatibility("1.3.0-beta.1", "1.3.0-beta.2") == (
+            "protocol-prerelease-mismatch",
+            "protocol prereleases must match exactly: client=1.3.0-beta.1 server=1.3.0-beta.2",
+        )
+        assert cdp_client._protocol_compatibility("1.2.4", "nope") == (
+            "protocol-invalid-version",
+            "invalid protocol version: client='1.2.4' server='nope'",
         )

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -601,6 +601,80 @@ async def test_preloaded_discovery_detaches_stale_worker_then_accepts_ready_work
         await client.close()
 
 
+async def test_preloaded_discovery_keeps_sweeping_when_compatible_worker_lacks_receiver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A compatible worker without its receiver yet outranks an incompatible sibling.
+
+    Sweep 1 sees [compatible-but-no-receiver, incompatible]; sweep 2 sees the compatible worker
+    ready. The incompatible sibling must not fail the connection fast.
+    """
+    get_targets_calls = 0
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    def response_for(message: dict[str, object]) -> dict[str, object]:
+        nonlocal get_targets_calls
+        method = message["method"]
+        if method == "Target.getTargets":
+            get_targets_calls += 1
+            return {
+                "result": {
+                    "targetInfos": [
+                        {
+                            "targetId": name,
+                            "type": "service_worker",
+                            "title": name,
+                            "url": f"chrome-extension://{name}/service-worker.js",
+                        }
+                        for name in ("pending", "stale")
+                    ]
+                }
+            }
+        if method == "Target.attachToTarget":
+            target_id = cast(dict[str, object], message["params"])["targetId"]
+            return {"result": {"sessionId": f"{target_id}-session"}}
+        if method == "Runtime.evaluate":
+            if message.get("sessionId") == "stale-session":
+                return {"result": {"result": {"value": _incompatible_marker()}}}
+            ready = _ready_marker()
+            if get_targets_calls == 1:
+                ready["hasReceiver"] = False
+            return {"result": {"result": {"value": ready}}}
+        return {"result": {}}
+
+    socket = FakeWebSocket(response_for)
+
+    async def resolve(_: str) -> str:
+        return "ws://127.0.0.1/devtools/browser/test"
+
+    async def connect(_: str) -> FakeWebSocket:
+        return socket
+
+    monkeypatch.setattr(cdp_client, "_resolve_browser_web_socket_url", resolve)
+    monkeypatch.setattr(cdp_client, "_connect_web_socket", connect)
+    monkeypatch.setattr(cdp_client.asyncio, "sleep", record_sleep)
+    client = await CDPClient.connect(
+        cdp_url="wss://browserbase",
+        preloaded_extension=True,
+    )
+    try:
+        assert client.service_worker.target_id == "pending"
+        assert get_targets_calls == 2
+        assert sleeps == [0.1]
+        detached = [
+            cast(dict[str, object], message["params"])["sessionId"]
+            for message in socket.sent
+            if message["method"] == "Target.detachFromTarget"
+        ]
+        # Sweep 1 detaches both probed workers; sweep 2 returns on the ready worker first.
+        assert detached == ["pending-session", "stale-session"]
+    finally:
+        await client.close()
+
+
 async def test_preloaded_discovery_fails_fast_on_a_foreign_runtime_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1076,6 +1150,39 @@ class TestNegotiateRuntime:
             ),
             ("string", "no Stagehand runtime marker"),
             ({"serverInfo": "not-a-mapping"}, "unreadable"),
+            ({"protocolVersion": STAGEHAND_PROTOCOL_VERSION, "serverInfo": None}, "unreadable"),
+            (
+                {
+                    "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
+                    "serverInfo": {"name": "stagehand"},
+                },
+                "serverInfo.version=None",
+            ),
+            (
+                {
+                    "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
+                    "serverInfo": {"name": "stagehand", "version": 1},
+                },
+                "serverInfo.version=1",
+            ),
+            (
+                {
+                    "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
+                    "serverInfo": {"name": "stagehand", "version": ""},
+                },
+                "serverInfo.version=''",
+            ),
+            (
+                {
+                    "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
+                    "serverInfo": {"name": "", "version": "1.0.0"},
+                },
+                "serverInfo.name=''",
+            ),
+            (
+                {"protocolVersion": "", "serverInfo": {"name": "stagehand", "version": "1.0.0"}},
+                "protocolVersion=''",
+            ),
         ],
     )
     def test_unreadable_markers_are_unknown_not_incompatible(
@@ -1097,7 +1204,8 @@ class TestNegotiateRuntime:
                     "serverInfo": {"name": "stagehand", "version": "0"},
                 },
                 "protocol-major-mismatch",
-                "major mismatch",
+                "Protocol major mismatch: "
+                f"client {STAGEHAND_PROTOCOL_VERSION}, server {INCOMPATIBLE_PROTOCOL_VERSION}",
             ),
             (
                 {
@@ -1105,7 +1213,7 @@ class TestNegotiateRuntime:
                     "serverInfo": {"name": "stagehand", "version": "2"},
                 },
                 "protocol-invalid-version",
-                "invalid protocol version",
+                f"Invalid protocol version: client {STAGEHAND_PROTOCOL_VERSION}, server not-semver",
             ),
             (
                 {
@@ -1113,7 +1221,7 @@ class TestNegotiateRuntime:
                     "serverInfo": {"name": "other", "version": "1"},
                 },
                 "runtime-name-mismatch",
-                "serverInfo.name='other'",
+                'Runtime name mismatch: expected "stagehand", server reported "other"',
             ),
             (
                 {
@@ -1121,7 +1229,8 @@ class TestNegotiateRuntime:
                     "serverInfo": {"name": "stagehand", "version": "1"},
                 },
                 "protocol-prerelease-mismatch",
-                "match exactly",
+                "Protocol prereleases must match exactly: "
+                f"client {STAGEHAND_PROTOCOL_VERSION}, server {STAGEHAND_PROTOCOL_VERSION}-beta.1",
             ),
         ],
     )
@@ -1133,17 +1242,26 @@ class TestNegotiateRuntime:
         assert result.kind == "incompatible"
         assert result.compatible is False
         assert result.reason == reason
-        assert expected in result.detail
+        # Exact match: the wording is shared verbatim with the TypeScript SDK.
+        assert result.detail == expected
         assert result.protocol_version == marker["protocolVersion"]
         server_info = cast(dict[str, object], marker["serverInfo"])
         assert result.server_name == server_info["name"]
         assert result.server_version == server_info["version"]
         error = StagehandRuntimeIncompatibleError(result)
         assert error.reason == reason
+        assert error.detail == expected
         assert error.client_protocol_version == STAGEHAND_PROTOCOL_VERSION
 
     def test_never_raises_on_hostile_input(self) -> None:
-        for marker in ("string", 42, [], {"serverInfo": "not-a-mapping"}, {"serverInfo": None}):
+        for marker in (
+            "string",
+            42,
+            [],
+            {"serverInfo": "not-a-mapping"},
+            {"serverInfo": None},
+            {"protocolVersion": "1.0.0", "serverInfo": {"name": "", "version": ""}},
+        ):
             assert cdp_client._negotiate_runtime(marker).kind == "unknown"
 
     def test_incompatible_error_rejects_non_incompatible_results(self) -> None:
@@ -1157,18 +1275,22 @@ class TestNegotiateRuntime:
         assert cdp_client._protocol_compatibility("1.2.4", "1.9.0") is None
         assert cdp_client._protocol_compatibility("1.2.4", "1.1.99") == (
             "protocol-server-too-old",
-            "server protocol 1.1.99 is older than client requirement 1.2.4",
+            "Server protocol 1.1.99 is older than client requirement 1.2.4",
         )
         assert cdp_client._protocol_compatibility("1.2.4", "2.0.0") == (
             "protocol-major-mismatch",
-            "protocol major mismatch: client=1.2.4 server=2.0.0",
+            "Protocol major mismatch: client 1.2.4, server 2.0.0",
         )
         assert cdp_client._protocol_compatibility("1.3.0-beta.1", "1.3.0-beta.1") is None
         assert cdp_client._protocol_compatibility("1.3.0-beta.1", "1.3.0-beta.2") == (
             "protocol-prerelease-mismatch",
-            "protocol prereleases must match exactly: client=1.3.0-beta.1 server=1.3.0-beta.2",
+            "Protocol prereleases must match exactly: client 1.3.0-beta.1, server 1.3.0-beta.2",
+        )
+        assert cdp_client._protocol_compatibility("1.3.0", "not-semver") == (
+            "protocol-invalid-version",
+            "Invalid protocol version: client 1.3.0, server not-semver",
         )
         assert cdp_client._protocol_compatibility("1.2.4", "nope") == (
             "protocol-invalid-version",
-            "invalid protocol version: client='1.2.4' server='nope'",
+            "Invalid protocol version: client 1.2.4, server nope",
         )

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -1186,6 +1186,10 @@ class TestNegotiateRuntime:
                 },
                 "serverInfo.name=1",
             ),
+            (
+                {"protocolVersion": "", "serverInfo": {"name": "stagehand", "version": "1"}},
+                "protocolVersion=''",
+            ),
         ],
     )
     def test_unreadable_markers_are_unknown_not_incompatible(
@@ -1224,7 +1228,7 @@ class TestNegotiateRuntime:
                     "serverInfo": {"name": "other", "version": "1"},
                 },
                 "runtime-name-mismatch",
-                'Connected runtime is not Stagehand: serverInfo.name="other"',
+                'Runtime name mismatch: expected "stagehand", server reported "other"',
             ),
             (
                 {

--- a/packages/sdk-ts/src/cdpClient.ts
+++ b/packages/sdk-ts/src/cdpClient.ts
@@ -118,6 +118,8 @@ export type IncompatibleRuntimeCompatibility = Extract<
  */
 export class StagehandRuntimeIncompatibleError extends Error {
   readonly reason: RuntimeIncompatibilityReason;
+  /** Human-readable negotiation outcome, e.g. the client/server versions that clashed. */
+  readonly detail: string;
   /** Protocol version this SDK speaks. */
   readonly clientProtocolVersion: string;
   /** Protocol version the connected extension reported. */
@@ -145,6 +147,7 @@ export class StagehandRuntimeIncompatibleError extends Error {
     );
     this.name = "StagehandRuntimeIncompatibleError";
     this.reason = compatibility.reason;
+    this.detail = compatibility.detail;
     this.clientProtocolVersion = compatibility.required.protocolVersion;
     this.extensionProtocolVersion = compatibility.reported.protocolVersion;
     this.extensionServerInfo = { ...compatibility.reported.serverInfo };
@@ -555,6 +558,9 @@ export async function waitForPreloadedStagehandServiceWorker(
         target.url.includes(workerUrlIncludes),
     );
     let incompatibleRuntime: IncompatibleRuntimeCompatibility | undefined;
+    // A compatible worker whose receiver is not installed yet must keep the sweep polling
+    // even when a sibling worker is incompatible.
+    let sawCompatibleMarker = false;
     for (const serviceWorker of candidates) {
       let sessionId: string | undefined;
       let keepAttached = false;
@@ -576,9 +582,12 @@ export async function waitForPreloadedStagehandServiceWorker(
             options.runtimeRequirement ?? DEFAULT_RUNTIME_REQUIREMENT,
             readiness.marker,
           );
-          if (compatibility.kind === "compatible" && readiness.hasReceiver) {
-            keepAttached = true;
-            return { serviceWorker, sessionId };
+          if (compatibility.kind === "compatible") {
+            sawCompatibleMarker = true;
+            if (readiness.hasReceiver) {
+              keepAttached = true;
+              return { serviceWorker, sessionId };
+            }
           }
           if (compatibility.kind === "incompatible" && options.allowFallbackInstall !== true) {
             incompatibleRuntime = compatibility;
@@ -596,9 +605,9 @@ export async function waitForPreloadedStagehandServiceWorker(
       }
     }
 
-    // No compatible worker in this sweep and at least one incompatible one: fail fast
+    // No compatible marker in this sweep and at least one incompatible one: fail fast
     // instead of re-polling until the initialization deadline.
-    if (incompatibleRuntime) {
+    if (incompatibleRuntime && !sawCompatibleMarker) {
       throw new StagehandRuntimeIncompatibleError(incompatibleRuntime);
     }
     await abortable(delayFn(pollIntervalMs), options.signal);

--- a/packages/sdk-ts/src/cdpClient.ts
+++ b/packages/sdk-ts/src/cdpClient.ts
@@ -8,7 +8,9 @@ import { z } from "zod/v4";
 import {
   DEFAULT_RUNTIME_REQUIREMENT,
   negotiateRuntimeCompatibility,
+  RUNTIME_INCOMPATIBILITY_REMEDIATION,
   type RuntimeCompatibility,
+  type RuntimeIncompatibilityReason,
   type RuntimeRequirement,
 } from "./runtimeCompatibility.js";
 import { abortable, abortableDelay, abortReason, throwIfAborted } from "./abort.js";
@@ -104,23 +106,48 @@ export function stagehandMessageExpression(message: JSONRPCMessage): string {
     : `void globalThis.__stagehandReceiveFromHost(${JSON.stringify(JSON.stringify(message))}); true`;
 }
 
+export type IncompatibleRuntimeCompatibility = Extract<
+  RuntimeCompatibility,
+  { kind: "incompatible" }
+>;
+
+/**
+ * Thrown as soon as the connected Stagehand extension reports a runtime marker
+ * that this SDK cannot talk to (protocol major mismatch, extension too old,
+ * prerelease mismatch, invalid version, or a foreign runtime name).
+ */
 export class StagehandRuntimeIncompatibleError extends Error {
-  readonly reason;
-  constructor(readonly compatibility: Extract<RuntimeCompatibility, { kind: "incompatible" }>) {
+  readonly reason: RuntimeIncompatibilityReason;
+  /** Protocol version this SDK speaks. */
+  readonly clientProtocolVersion: string;
+  /** Protocol version the connected extension reported. */
+  readonly extensionProtocolVersion: string;
+  /** `serverInfo` reported by the connected extension. */
+  readonly extensionServerInfo: { name: string; version: string };
+  readonly remediation = RUNTIME_INCOMPATIBILITY_REMEDIATION;
+
+  constructor(readonly compatibility: IncompatibleRuntimeCompatibility) {
     super(
-      "Incompatible Stagehand runtime: " +
+      "Incompatible Stagehand runtime (" +
+        compatibility.reason +
+        "): " +
         compatibility.detail +
         "; client protocol " +
         compatibility.required.protocolVersion +
-        ", reported protocol " +
+        ", extension protocol " +
         String(compatibility.reported.protocolVersion) +
-        ", server " +
+        ", extension " +
         compatibility.reported.serverInfo.name +
         "/" +
-        compatibility.reported.serverInfo.version,
+        compatibility.reported.serverInfo.version +
+        ". " +
+        RUNTIME_INCOMPATIBILITY_REMEDIATION,
     );
     this.name = "StagehandRuntimeIncompatibleError";
     this.reason = compatibility.reason;
+    this.clientProtocolVersion = compatibility.required.protocolVersion;
+    this.extensionProtocolVersion = compatibility.reported.protocolVersion;
+    this.extensionServerInfo = { ...compatibility.reported.serverInfo };
   }
 }
 
@@ -487,7 +514,9 @@ export async function waitForRuntimeReady(
         options.runtimeRequirement ?? DEFAULT_RUNTIME_REQUIREMENT,
         readiness.marker,
       );
-      if (compatibility.kind === "incompatible" && options.allowFallbackInstall === false)
+      // Fail fast by default; allowFallbackInstall is reserved for a future
+      // Browserbase preloaded-extension flow that may replace the runtime.
+      if (compatibility.kind === "incompatible" && options.allowFallbackInstall !== true)
         throw new StagehandRuntimeIncompatibleError(compatibility);
       if (compatibility.kind === "compatible" && readiness.hasReceiver) return;
     }
@@ -525,7 +554,7 @@ export async function waitForPreloadedStagehandServiceWorker(
         target.url.startsWith("chrome-extension://") &&
         target.url.includes(workerUrlIncludes),
     );
-    let incompatibleRuntime: Extract<RuntimeCompatibility, { kind: "incompatible" }> | undefined;
+    let incompatibleRuntime: IncompatibleRuntimeCompatibility | undefined;
     for (const serviceWorker of candidates) {
       let sessionId: string | undefined;
       let keepAttached = false;
@@ -551,7 +580,7 @@ export async function waitForPreloadedStagehandServiceWorker(
             keepAttached = true;
             return { serviceWorker, sessionId };
           }
-          if (compatibility.kind === "incompatible" && options.allowFallbackInstall === false) {
+          if (compatibility.kind === "incompatible" && options.allowFallbackInstall !== true) {
             incompatibleRuntime = compatibility;
           }
         }
@@ -567,6 +596,8 @@ export async function waitForPreloadedStagehandServiceWorker(
       }
     }
 
+    // No compatible worker in this sweep and at least one incompatible one: fail fast
+    // instead of re-polling until the initialization deadline.
     if (incompatibleRuntime) {
       throw new StagehandRuntimeIncompatibleError(incompatibleRuntime);
     }

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -40,6 +40,16 @@ export {
 export { WebMCPInvocation, WebMCPTool } from "./webmcp.js";
 export type { InitScriptSource } from "./pageScripts.js";
 export { Stagehand, type ExtractResult } from "./stagehand.js";
+export {
+  StagehandRuntimeIncompatibleError,
+  type IncompatibleRuntimeCompatibility,
+} from "./cdpClient.js";
+export type {
+  ReportedRuntime,
+  RuntimeCompatibility,
+  RuntimeIncompatibilityReason,
+  RuntimeRequirement,
+} from "./runtimeCompatibility.js";
 export type {
   ExperimentalBatchCallback,
   ExperimentalBatchBrowserContext,

--- a/packages/sdk-ts/src/runtimeCompatibility.ts
+++ b/packages/sdk-ts/src/runtimeCompatibility.ts
@@ -77,7 +77,7 @@ export function negotiateRuntimeCompatibility(
     if (reported.serverInfo.name !== STAGEHAND_RUNTIME_NAME)
       return incompatible(
         "runtime-name-mismatch",
-        `Runtime name mismatch: expected "${STAGEHAND_RUNTIME_NAME}", server reported "${reported.serverInfo.name}"`,
+        `Connected runtime is not Stagehand: serverInfo.name=${JSON.stringify(reported.serverInfo.name)}`,
         required,
         reported,
       );

--- a/packages/sdk-ts/src/runtimeCompatibility.ts
+++ b/packages/sdk-ts/src/runtimeCompatibility.ts
@@ -77,7 +77,7 @@ export function negotiateRuntimeCompatibility(
     if (reported.serverInfo.name !== STAGEHAND_RUNTIME_NAME)
       return incompatible(
         "runtime-name-mismatch",
-        `Connected runtime is not Stagehand: serverInfo.name=${JSON.stringify(reported.serverInfo.name)}`,
+        `Runtime name mismatch: expected "${STAGEHAND_RUNTIME_NAME}", server reported "${reported.serverInfo.name}"`,
         required,
         reported,
       );

--- a/packages/sdk-ts/src/runtimeCompatibility.ts
+++ b/packages/sdk-ts/src/runtimeCompatibility.ts
@@ -1,11 +1,25 @@
-import type { ImplementationInfo, RuntimeDescriptor } from "../../protocol/types.js";
-import { RuntimeDescriptorSchema, STAGEHAND_PROTOCOL_VERSION } from "../../protocol/schemas.js";
-import { checkProtocolCompatibility } from "../../protocol/protocol-version.js";
+import type { ImplementationInfo } from "../../protocol/types.js";
+import { ImplementationInfoSchema, STAGEHAND_PROTOCOL_VERSION } from "../../protocol/schemas.js";
+import {
+  checkProtocolCompatibility,
+  StagehandProtocolVersionSchema,
+} from "../../protocol/protocol-version.js";
 import { z } from "zod/v4";
 
 export type RuntimeRequirement = {
   protocolVersion: string;
 };
+/** The runtime marker as reported by the extension, before the runtime name is validated. */
+export type ReportedRuntime = {
+  protocolVersion: string;
+  serverInfo: ImplementationInfo;
+};
+export type RuntimeIncompatibilityReason =
+  | "protocol-invalid-version"
+  | "protocol-major-mismatch"
+  | "protocol-server-too-old"
+  | "protocol-prerelease-mismatch"
+  | "runtime-name-mismatch";
 export type RuntimeCompatibility =
   | {
       kind: "compatible";
@@ -14,14 +28,10 @@ export type RuntimeCompatibility =
     }
   | {
       kind: "incompatible";
-      reason:
-        | "protocol-invalid-version"
-        | "protocol-major-mismatch"
-        | "protocol-server-too-old"
-        | "protocol-prerelease-mismatch";
+      reason: RuntimeIncompatibilityReason;
       detail: string;
       required: RuntimeRequirement;
-      reported: RuntimeDescriptor;
+      reported: ReportedRuntime;
     }
   | {
       kind: "unknown";
@@ -31,6 +41,18 @@ export type RuntimeCompatibility =
 
 export const DEFAULT_RUNTIME_REQUIREMENT: RuntimeRequirement = Object.freeze({
   protocolVersion: STAGEHAND_PROTOCOL_VERSION,
+});
+
+export const STAGEHAND_RUNTIME_NAME = "stagehand";
+
+export const RUNTIME_INCOMPATIBILITY_REMEDIATION =
+  "Upgrade the Stagehand SDK and the Stagehand extension together so their protocol majors match, " +
+  "or start the session with the extension bundled in this SDK.";
+
+// Accepts any runtime name so a foreign runtime is reported as incompatible rather than unknown.
+const ReportedRuntimeSchema = z.strictObject({
+  protocolVersion: StagehandProtocolVersionSchema,
+  serverInfo: ImplementationInfoSchema,
 });
 
 export function negotiateRuntimeCompatibility(
@@ -45,7 +67,7 @@ export function negotiateRuntimeCompatibility(
     };
 
   try {
-    const result = RuntimeDescriptorSchema.safeParse(raw);
+    const result = ReportedRuntimeSchema.safeParse(raw);
     if (!result.success)
       return {
         kind: "unknown",
@@ -54,11 +76,18 @@ export function negotiateRuntimeCompatibility(
       };
 
     const reported = descriptor(result.data);
+    if (reported.serverInfo.name !== STAGEHAND_RUNTIME_NAME)
+      return incompatible(
+        "runtime-name-mismatch",
+        `Runtime name mismatch: expected "${STAGEHAND_RUNTIME_NAME}", server reported "${reported.serverInfo.name}"`,
+        required,
+        reported,
+      );
     const compatibility = checkProtocolCompatibility(
       required.protocolVersion,
       reported.protocolVersion,
     );
-    if (!compatibility.compatible)
+    if (compatibility.compatible === false)
       return incompatible(
         compatibility.reason,
         compatibilityDetail(
@@ -84,7 +113,7 @@ export function negotiateRuntimeCompatibility(
 }
 
 function compatibilityDetail(
-  reason: Extract<RuntimeCompatibility, { kind: "incompatible" }>["reason"],
+  reason: Exclude<RuntimeIncompatibilityReason, "runtime-name-mismatch">,
   clientVersion: string,
   serverVersion: string,
 ): string {
@@ -100,7 +129,7 @@ function compatibilityDetail(
   }
 }
 
-function descriptor(value: RuntimeDescriptor): RuntimeDescriptor {
+function descriptor(value: ReportedRuntime): ReportedRuntime {
   return {
     protocolVersion: value.protocolVersion,
     serverInfo: { ...value.serverInfo },
@@ -108,10 +137,10 @@ function descriptor(value: RuntimeDescriptor): RuntimeDescriptor {
 }
 
 function incompatible(
-  reason: Extract<RuntimeCompatibility, { kind: "incompatible" }>["reason"],
+  reason: RuntimeIncompatibilityReason,
   detail: string,
   required: RuntimeRequirement,
-  reported: RuntimeDescriptor,
+  reported: ReportedRuntime,
 ): RuntimeCompatibility {
   return {
     kind: "incompatible",

--- a/packages/sdk-ts/src/runtimeCompatibility.ts
+++ b/packages/sdk-ts/src/runtimeCompatibility.ts
@@ -1,9 +1,6 @@
 import type { ImplementationInfo } from "../../protocol/types.js";
 import { ImplementationInfoSchema, STAGEHAND_PROTOCOL_VERSION } from "../../protocol/schemas.js";
-import {
-  checkProtocolCompatibility,
-  StagehandProtocolVersionSchema,
-} from "../../protocol/protocol-version.js";
+import { checkProtocolCompatibility } from "../../protocol/protocol-version.js";
 import { z } from "zod/v4";
 
 export type RuntimeRequirement = {
@@ -49,9 +46,10 @@ export const RUNTIME_INCOMPATIBILITY_REMEDIATION =
   "Upgrade the Stagehand SDK and the Stagehand extension together so their protocol majors match, " +
   "or start the session with the extension bundled in this SDK.";
 
-// Accepts any runtime name so a foreign runtime is reported as incompatible rather than unknown.
+// Accepts any runtime name and any non-empty protocolVersion string so a foreign runtime or a
+// non-SemVer protocol version is reported as incompatible (fail fast) rather than unknown (poll).
 const ReportedRuntimeSchema = z.strictObject({
-  protocolVersion: StagehandProtocolVersionSchema,
+  protocolVersion: z.string().min(1),
   serverInfo: ImplementationInfoSchema,
 });
 

--- a/packages/sdk-ts/tests/cdpClient.test.ts
+++ b/packages/sdk-ts/tests/cdpClient.test.ts
@@ -48,6 +48,17 @@ const foreignRuntimeReadiness: RuntimeReadiness = {
   },
   hasReceiver: true,
 };
+const compatibleWithoutReceiverReadiness: RuntimeReadiness = {
+  marker: compatibleReadiness.marker,
+  hasReceiver: false,
+};
+const invalidVersionReadiness: RuntimeReadiness = {
+  marker: {
+    protocolVersion: "not-semver",
+    serverInfo: { name: "stagehand", version: "1.0.0" },
+  },
+  hasReceiver: true,
+};
 const unknownReadiness: RuntimeReadiness = { marker: null, hasReceiver: false };
 
 /** A CDP stub whose Runtime.evaluate answers come from `readiness`, one entry per poll. */
@@ -285,6 +296,11 @@ describe("runtime compatibility fail-fast", () => {
     expect(error).toBeInstanceOf(StagehandRuntimeIncompatibleError);
     if (!(error instanceof StagehandRuntimeIncompatibleError)) throw error;
     expect(error.reason).toBe("protocol-major-mismatch");
+    expect(error.detail).toBe(
+      `Protocol major mismatch: client ${STAGEHAND_PROTOCOL_VERSION}, server ${NEXT_MAJOR_PROTOCOL_VERSION}`,
+    );
+    expect(error.detail).toBe(error.compatibility.detail);
+    expect(error.message).toContain(error.detail);
     expect(error.clientProtocolVersion).toBe(STAGEHAND_PROTOCOL_VERSION);
     expect(error.extensionProtocolVersion).toBe(NEXT_MAJOR_PROTOCOL_VERSION);
     expect(error.extensionServerInfo).toStrictEqual({ name: "stagehand", version: "9.9.9" });
@@ -314,6 +330,25 @@ describe("runtime compatibility fail-fast", () => {
       reason: "runtime-name-mismatch",
       extensionServerInfo: { name: "other-runtime", version: "1.0.0" },
     });
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(delayFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-SemVer protocol version as protocol-invalid-version instead of polling", async () => {
+    const { cdp, evaluate } = readinessCdp([invalidVersionReadiness]);
+    const delayFn = vi.fn(async () => {});
+
+    const error = await rejectionOf(
+      waitForRuntimeReady(cdp, "worker-session", { delayFn, signal }),
+    );
+
+    expect(error).toBeInstanceOf(StagehandRuntimeIncompatibleError);
+    if (!(error instanceof StagehandRuntimeIncompatibleError)) throw error;
+    expect(error.reason).toBe("protocol-invalid-version");
+    expect(error.extensionProtocolVersion).toBe("not-semver");
+    expect(error.detail).toBe(
+      `Invalid protocol version: client ${STAGEHAND_PROTOCOL_VERSION}, server not-semver`,
+    );
     expect(evaluate).toHaveBeenCalledTimes(1);
     expect(delayFn).not.toHaveBeenCalled();
   });
@@ -408,5 +443,79 @@ describe("runtime compatibility fail-fast", () => {
     ).resolves.toMatchObject({ sessionId: "worker-session" });
     expect(evaluate).toHaveBeenCalledTimes(2);
     expect(delayFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps sweeping when a compatible worker lacks its receiver even if a sibling is incompatible", async () => {
+    // Sweep 1: the compatible worker has published its marker but not installed the receiver
+    // yet, and a stale sibling worker is incompatible. Sweep 2: the compatible worker is ready.
+    const compatibleWorker = {
+      targetId: "compatible-target",
+      type: "service_worker",
+      title: "Stagehand",
+      url: "chrome-extension://compatible/service-worker.js",
+    };
+    const incompatibleWorker = {
+      targetId: "incompatible-target",
+      type: "service_worker",
+      title: "Stagehand (stale)",
+      url: "chrome-extension://incompatible/service-worker.js",
+    };
+    let sweeps = 0;
+    const evaluate = vi.fn((sessionId: string | undefined) => {
+      if (sessionId === "incompatible-session") return { result: { value: incompatibleReadiness } };
+      return {
+        result: {
+          value: sweeps === 1 ? compatibleWithoutReceiverReadiness : compatibleReadiness,
+        },
+      };
+    });
+    const sendCommand = vi.fn(
+      async (
+        method: string,
+        params?: Record<string, unknown>,
+        sessionId?: string,
+      ): Promise<Record<string, unknown>> => {
+        if (method === "Target.getTargets") {
+          sweeps += 1;
+          return { targetInfos: [compatibleWorker, incompatibleWorker] };
+        }
+        if (method === "Target.attachToTarget") {
+          return { sessionId: `${String(params?.targetId).replace("-target", "")}-session` };
+        }
+        if (method === "Runtime.evaluate") return evaluate(sessionId);
+        return {};
+      },
+    );
+    const cdp = {
+      async sendCommand<Result = Record<string, unknown>>(
+        method: string,
+        params?: Record<string, unknown>,
+        sessionId?: string,
+      ): Promise<Result> {
+        return (await sendCommand(method, params, sessionId)) as Result;
+      },
+    };
+    const delayFn = vi.fn(async () => {});
+
+    await expect(
+      waitForPreloadedStagehandServiceWorker(cdp, { delayFn, signal }),
+    ).resolves.toMatchObject({
+      sessionId: "compatible-session",
+      serviceWorker: { targetId: "compatible-target" },
+    });
+    expect(sweeps).toBe(2);
+    expect(delayFn).toHaveBeenCalledTimes(1);
+    expect(sendCommand).toHaveBeenCalledWith(
+      "Target.detachFromTarget",
+      { sessionId: "incompatible-session" },
+      undefined,
+    );
+    // Detached once after the receiver-less probe in sweep 1, then kept attached in sweep 2.
+    expect(
+      sendCommand.mock.calls.filter(
+        ([method, params]) =>
+          method === "Target.detachFromTarget" && params?.sessionId === "compatible-session",
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/packages/sdk-ts/tests/cdpClient.test.ts
+++ b/packages/sdk-ts/tests/cdpClient.test.ts
@@ -1,13 +1,101 @@
 import { runInNewContext } from "node:vm";
 import { describe, expect, it, vi } from "vitest";
+import { STAGEHAND_PROTOCOL_VERSION } from "../../protocol/schemas.js";
 import {
   CDPClient,
   CDPConnectionClosedError,
   openCDPWebSocket,
   stagehandMessageExpression,
+  StagehandRuntimeIncompatibleError,
+  waitForPreloadedStagehandServiceWorker,
   waitForRuntimeReady,
   waitForServiceWorker,
 } from "../src/cdpClient.js";
+import { RUNTIME_INCOMPATIBILITY_REMEDIATION } from "../src/runtimeCompatibility.js";
+import * as publicEntry from "../src/index.js";
+
+const NEXT_MAJOR_PROTOCOL_VERSION = `${Number(STAGEHAND_PROTOCOL_VERSION.split(".")[0]) + 1}.0.0`;
+
+type RuntimeReadiness = { marker: unknown; hasReceiver: boolean };
+
+async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+  return await promise.then(
+    () => {
+      throw new Error("expected the promise to reject");
+    },
+    (cause: unknown) => cause,
+  );
+}
+
+const compatibleReadiness: RuntimeReadiness = {
+  marker: {
+    protocolVersion: STAGEHAND_PROTOCOL_VERSION,
+    serverInfo: { name: "stagehand", version: "1.0.0" },
+  },
+  hasReceiver: true,
+};
+const incompatibleReadiness: RuntimeReadiness = {
+  marker: {
+    protocolVersion: NEXT_MAJOR_PROTOCOL_VERSION,
+    serverInfo: { name: "stagehand", version: "9.9.9" },
+  },
+  hasReceiver: true,
+};
+const foreignRuntimeReadiness: RuntimeReadiness = {
+  marker: {
+    protocolVersion: STAGEHAND_PROTOCOL_VERSION,
+    serverInfo: { name: "other-runtime", version: "1.0.0" },
+  },
+  hasReceiver: true,
+};
+const unknownReadiness: RuntimeReadiness = { marker: null, hasReceiver: false };
+
+/** A CDP stub whose Runtime.evaluate answers come from `readiness`, one entry per poll. */
+function readinessCdp(readiness: RuntimeReadiness[]) {
+  const evaluations: RuntimeReadiness[] = [...readiness];
+  const evaluate = vi.fn(() => {
+    const next = evaluations.length > 1 ? evaluations.shift() : evaluations[0];
+    return { result: { value: next } };
+  });
+  const sendCommand = vi.fn(
+    async (
+      method: string,
+      _params?: Record<string, unknown>,
+      sessionId?: string,
+    ): Promise<Record<string, unknown>> => {
+      if (method === "Runtime.evaluate") return evaluate();
+      if (method === "Target.getTargets") {
+        return {
+          targetInfos: [
+            {
+              targetId: "worker-target",
+              type: "service_worker",
+              title: "Stagehand",
+              url: "chrome-extension://stagehand/service-worker.js",
+            },
+          ],
+        };
+      }
+      if (method === "Target.attachToTarget") return { sessionId: sessionId ?? "worker-session" };
+      return {};
+    },
+  );
+  return {
+    evaluate,
+    sendCommand,
+    cdp: {
+      async sendCommand<Result = Record<string, unknown>>(
+        method: string,
+        params?: Record<string, unknown>,
+        sessionId?: string,
+        signal?: AbortSignal,
+      ): Promise<Result> {
+        void signal;
+        return (await sendCommand(method, params, sessionId)) as Result;
+      },
+    },
+  };
+}
 
 describe("callback batch expression", () => {
   it("serializes input separately from executable callback source", () => {
@@ -176,5 +264,149 @@ describe("CDP WebSocket transport", () => {
       undefined,
       undefined,
     );
+  });
+});
+
+describe("runtime compatibility fail-fast", () => {
+  const signal = new AbortController().signal;
+
+  it("exports StagehandRuntimeIncompatibleError from the public entry", () => {
+    expect(publicEntry.StagehandRuntimeIncompatibleError).toBe(StagehandRuntimeIncompatibleError);
+  });
+
+  it("rejects an incompatible runtime marker on the first poll by default", async () => {
+    const { cdp, evaluate } = readinessCdp([incompatibleReadiness]);
+    const delayFn = vi.fn(async () => {});
+
+    const error = await rejectionOf(
+      waitForRuntimeReady(cdp, "worker-session", { delayFn, signal }),
+    );
+
+    expect(error).toBeInstanceOf(StagehandRuntimeIncompatibleError);
+    if (!(error instanceof StagehandRuntimeIncompatibleError)) throw error;
+    expect(error.reason).toBe("protocol-major-mismatch");
+    expect(error.clientProtocolVersion).toBe(STAGEHAND_PROTOCOL_VERSION);
+    expect(error.extensionProtocolVersion).toBe(NEXT_MAJOR_PROTOCOL_VERSION);
+    expect(error.extensionServerInfo).toStrictEqual({ name: "stagehand", version: "9.9.9" });
+    expect(error.remediation).toBe(RUNTIME_INCOMPATIBILITY_REMEDIATION);
+    expect(error.compatibility).toMatchObject({
+      kind: "incompatible",
+      reason: "protocol-major-mismatch",
+      required: { protocolVersion: STAGEHAND_PROTOCOL_VERSION },
+    });
+    expect(error.message).toContain("protocol-major-mismatch");
+    expect(error.message).toContain(`client protocol ${STAGEHAND_PROTOCOL_VERSION}`);
+    expect(error.message).toContain(`extension protocol ${NEXT_MAJOR_PROTOCOL_VERSION}`);
+    expect(error.message).toContain("extension stagehand/9.9.9");
+    expect(error.message).toContain(RUNTIME_INCOMPATIBILITY_REMEDIATION);
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(delayFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects a runtime that reports a foreign runtime name", async () => {
+    const { cdp, evaluate } = readinessCdp([foreignRuntimeReadiness]);
+    const delayFn = vi.fn(async () => {});
+
+    const waiting = waitForRuntimeReady(cdp, "worker-session", { delayFn, signal });
+
+    await expect(waiting).rejects.toMatchObject({
+      name: "StagehandRuntimeIncompatibleError",
+      reason: "runtime-name-mismatch",
+      extensionServerInfo: { name: "other-runtime", version: "1.0.0" },
+    });
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(delayFn).not.toHaveBeenCalled();
+  });
+
+  it("keeps polling through unknown markers until the runtime is compatible", async () => {
+    const { cdp, evaluate } = readinessCdp([
+      unknownReadiness,
+      unknownReadiness,
+      unknownReadiness,
+      compatibleReadiness,
+    ]);
+    const delayFn = vi.fn(async () => {});
+
+    await expect(
+      waitForRuntimeReady(cdp, "worker-session", { delayFn, signal }),
+    ).resolves.toBeUndefined();
+    expect(evaluate).toHaveBeenCalledTimes(4);
+    expect(delayFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps polling past an incompatible marker when fallback install is allowed", async () => {
+    const { cdp, evaluate } = readinessCdp([incompatibleReadiness, compatibleReadiness]);
+    const delayFn = vi.fn(async () => {});
+
+    await expect(
+      waitForRuntimeReady(cdp, "worker-session", {
+        delayFn,
+        signal,
+        allowFallbackInstall: true,
+      }),
+    ).resolves.toBeUndefined();
+    expect(evaluate).toHaveBeenCalledTimes(2);
+    expect(delayFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("still fails fast when fallback install is explicitly disabled", async () => {
+    const { cdp, evaluate } = readinessCdp([incompatibleReadiness]);
+    const delayFn = vi.fn(async () => {});
+
+    await expect(
+      waitForRuntimeReady(cdp, "worker-session", {
+        delayFn,
+        signal,
+        allowFallbackInstall: false,
+      }),
+    ).rejects.toBeInstanceOf(StagehandRuntimeIncompatibleError);
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(delayFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects an incompatible preloaded service worker in the first sweep", async () => {
+    const { cdp, evaluate, sendCommand } = readinessCdp([incompatibleReadiness]);
+    const delayFn = vi.fn(async () => {});
+
+    const waiting = waitForPreloadedStagehandServiceWorker(cdp, { delayFn, signal });
+
+    await expect(waiting).rejects.toBeInstanceOf(StagehandRuntimeIncompatibleError);
+    await expect(waiting).rejects.toMatchObject({ reason: "protocol-major-mismatch" });
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(delayFn).not.toHaveBeenCalled();
+    expect(sendCommand).toHaveBeenCalledWith(
+      "Target.detachFromTarget",
+      { sessionId: "worker-session" },
+      undefined,
+    );
+  });
+
+  it("keeps sweeping preloaded workers through unknown markers until one is compatible", async () => {
+    const { cdp, evaluate } = readinessCdp([
+      unknownReadiness,
+      unknownReadiness,
+      compatibleReadiness,
+    ]);
+    const delayFn = vi.fn(async () => {});
+
+    await expect(
+      waitForPreloadedStagehandServiceWorker(cdp, { delayFn, signal }),
+    ).resolves.toMatchObject({
+      sessionId: "worker-session",
+      serviceWorker: { targetId: "worker-target" },
+    });
+    expect(evaluate).toHaveBeenCalledTimes(3);
+    expect(delayFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps sweeping preloaded workers past an incompatible marker when fallback install is allowed", async () => {
+    const { cdp, evaluate } = readinessCdp([incompatibleReadiness, compatibleReadiness]);
+    const delayFn = vi.fn(async () => {});
+
+    await expect(
+      waitForPreloadedStagehandServiceWorker(cdp, { delayFn, signal, allowFallbackInstall: true }),
+    ).resolves.toMatchObject({ sessionId: "worker-session" });
+    expect(evaluate).toHaveBeenCalledTimes(2);
+    expect(delayFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sdk-ts/tests/runtimeCompatibility.test.ts
+++ b/packages/sdk-ts/tests/runtimeCompatibility.test.ts
@@ -75,15 +75,20 @@ describe("negotiateRuntimeCompatibility", () => {
         reason: "unreadable-marker",
       }),
   );
-  it("reports a foreign marker as unreadable", () =>
+  it("reports a foreign runtime name as incompatible", () =>
     expect(
       negotiateRuntimeCompatibility(requirement, {
         ...marker("1.2.4"),
         serverInfo: { name: "other", version: "1.0.0" },
       }),
     ).toMatchObject({
-      kind: "unknown",
-      reason: "unreadable-marker",
+      kind: "incompatible",
+      reason: "runtime-name-mismatch",
+      required: { protocolVersion: "1.2.4" },
+      reported: {
+        protocolVersion: "1.2.4",
+        serverInfo: { name: "other", version: "1.0.0" },
+      },
     }));
   it("reports unknown marker keys as unreadable", () =>
     expect(

--- a/packages/sdk-ts/tests/runtimeCompatibility.test.ts
+++ b/packages/sdk-ts/tests/runtimeCompatibility.test.ts
@@ -60,6 +60,24 @@ describe("negotiateRuntimeCompatibility", () => {
       kind: "incompatible",
       reason: "protocol-invalid-version",
     }));
+  it("reports a non-SemVer server protocol version as incompatible so callers fail fast", () =>
+    expect(negotiateRuntimeCompatibility(requirement, marker("not-semver"))).toMatchObject({
+      kind: "incompatible",
+      reason: "protocol-invalid-version",
+      detail: `Invalid protocol version: client ${requirement.protocolVersion}, server not-semver`,
+      reported: { protocolVersion: "not-semver" },
+    }));
+  it.each([
+    [{ protocolVersion: "", serverInfo: { name: "stagehand", version: "1.0.0" } }],
+    [{ protocolVersion: "1.2.4", serverInfo: { name: "stagehand", version: "" } }],
+    [{ protocolVersion: "1.2.4", serverInfo: { name: "", version: "1.0.0" } }],
+    [{ protocolVersion: "1.2.4", serverInfo: { name: "stagehand" } }],
+  ])("reports an empty or missing marker field as unreadable for %j", (raw) =>
+    expect(negotiateRuntimeCompatibility(requirement, raw)).toMatchObject({
+      kind: "unknown",
+      reason: "unreadable-marker",
+    }),
+  );
   it.each([[null], [undefined]])("reports a missing marker for %s", (raw) =>
     expect(negotiateRuntimeCompatibility(requirement, raw)).toMatchObject({
       kind: "unknown",


### PR DESCRIPTION
## Why

When the connected Stagehand extension publishes a runtime marker (`globalThis.__stagehand_runtime`) whose protocol version is incompatible with the SDK, the client today keeps re-polling every 100 ms until the 60 s init deadline and the user only ever sees `Stagehand initialization timed out after 60000ms`. The wait loops only threw when `allowFallbackInstall === false`, and nothing sets that flag, so the fail-fast path was dead code (Python and Go had no fail-fast path at all).

## What changed

All three SDKs now share the same semantics:

- **Three-way negotiation**: `compatible` | `incompatible` (marker present and parses, but the protocol rules reject it, or `serverInfo.name !== "stagehand"`) | `unknown` (marker absent / not yet set / unparseable). Python and Go previously collapsed `incompatible` and `unknown` into a single `false`.
- **Wait loops**: `unknown` (and `Runtime.evaluate` exceptions) keep polling as before. `incompatible` raises on the **first** poll that sees it, before any sleep. In the preloaded-service-worker sweep a compatible worker in the same sweep still wins; an incompatible-only sweep raises immediately.
- **`allowFallbackInstall` is kept** (reserved for a future Browserbase preloaded-extension flow) but its default flips: the gate is now `!== true` instead of `=== false`. Passing `true` preserves the old keep-polling behaviour. Python/Go expose it only as an internal keyword/option on the wait functions (no new public constructor surface).
- **Dedicated, catchable error** carrying `reason` (`protocol-major-mismatch` / `protocol-server-too-old` / `protocol-prerelease-mismatch` / `protocol-invalid-version` / `runtime-name-mismatch`), client protocol version, reported extension protocol version, extension `serverInfo` name+version, and a remediation hint. Message shape is identical across SDKs:
  `Incompatible Stagehand runtime (<reason>): <detail>; client protocol <client>, extension protocol <ext>, extension <name>/<version>. Upgrade the Stagehand SDK and the Stagehand extension together so their protocol majors match, or start the session with the extension bundled in this SDK.`


## Test plan

Per SDK: (a) incompatible marker (major = current `STAGEHAND_PROTOCOL_VERSION` major + 1, never hardcoded) → dedicated error on the first poll, exactly one `Runtime.evaluate`, zero sleeps; (b) unknown marker for N polls then compatible → succeeds; (c) `allowFallbackInstall: true` + incompatible → keeps polling; (d) wrong `serverInfo.name` → error; (e) preloaded sweep: incompatible-only sweep fails fast and detaches, unknown sweeps keep polling; (f) error type exported from the public entry.

- `pnpm --filter ./packages/sdk-ts test`: 16 files passed, 1 skipped; 210 tests passed, 3 skipped
- `uv run --locked pytest` (sdk-python): 469 passed, 1 skipped (pre-existing py3.12 skip)
- `go test ./...` (sdk-go, excluding examples): all packages ok; `go test -race` on the CDP/runtime tests ok
- `just build` and `just check` (run step-by-step) green: changesets, changelog consolidation, python version sync, `pnpm check` (0 lint errors), `uv lock --check`, generate --check, ruff format/check, ty, Go generator --check, extensionpack --check, gofmt, go vet.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails fast with a clear compatibility error when the connected Stagehand extension reports an incompatible protocol version, instead of polling until the 60s initialization timeout. The old behavior produced an opaque "initialization timed out" message; now all three SDKs (TypeScript, Python, Go) raise a dedicated, catchable error with the mismatch reason, both protocol versions, and a remediation hint.

**Behavior changes**
- Adds a three-way runtime negotiation (`compatible` / `incompatible` / `unknown`); `incompatible` raises on the first poll, `unknown` keeps polling.
- A missing, empty, or non-string `serverInfo` field, and an empty `protocolVersion`, count as `unknown` in all three SDKs; a non-SemVer protocol version counts as `incompatible`.
- The preloaded service-worker sweep fails fast only when it saw an incompatible worker and no compatible marker, so a compatible worker still being set up keeps polling.
- Introduces `StagehandRuntimeIncompatibleError`, exported from all SDK entry points, carrying reason, detail, client/extension protocol versions, extension server info, and a remediation hint; wording is identical across SDKs, including the `runtime-name-mismatch` message.
- Flips `allowFallbackInstall` default: now fails fast unless explicitly set to `true` (reserved for a future preloaded-extension flow).
- Updates the protocol package's mirrored wait-loop fixtures and the extension test fixture to the new default.

<sup>Written for commit 9583b0f70509d4e66d5bd4ebf96f646e1481c898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

