### PR TITLE
docs: pin quickstart and installation Zod to compatible 4.4 minor

### DIFF
--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -14,8 +14,10 @@ The quickest way to start with Stagehand is to install the SDK, point it at a br
 ```bash
 mkdir my-stagehand-app && cd my-stagehand-app
 pnpm init -y
-pnpm install @browserbasehq/stagehand zod
+pnpm install @browserbasehq/stagehand 'zod@~4.4.3'
 ```
+
+Keep Zod on the `4.4.x` minor version to match Stagehand's supported types. Newer Zod minor versions can cause TypeScript errors when passing schemas to `extract()`.
 </Tab>
 
 <Tab title="Python">


### PR DESCRIPTION
## Summary
- Install `zod@~4.4.3` in the v4 TypeScript quickstart and installation docs to allow patch updates without pulling incompatible minor versions.
- Update installation commands for pnpm, npm, Yarn, and Bun.
- Explain in the quickstart why schemas from newer Zod minors can cause `extract()` TypeScript errors.

## Verification
- `git diff --check` passed for both changes.
- Isolated consumer typecheck with published Stagehand 4.1.0 passes with Zod 4.4.3 and fails with 4.6.1/4.6.2.
- Documentation validation suite not run (dependencies not installed in this isolated worktree).

This is a docs-only mitigation; it does not change SDK dependencies or the public schema contract.