### PR TITLE
docs: pin installation Zod to compatible 4.4 minor

### DIFF
--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -16,10 +16,10 @@ Node.js is the recommended runtime environment for Stagehand scripts. Stagehand 
 <Tabs>
 <Tab title="TypeScript">
 ```bash
-pnpm add @browserbasehq/stagehand zod
-# npm install @browserbasehq/stagehand zod
-# yarn add @browserbasehq/stagehand zod
-# bun add @browserbasehq/stagehand zod
+pnpm add @browserbasehq/stagehand 'zod@~4.4.3'
+# npm install @browserbasehq/stagehand 'zod@~4.4.3'
+# yarn add @browserbasehq/stagehand 'zod@~4.4.3'
+# bun add @browserbasehq/stagehand 'zod@~4.4.3'
 ```
 </Tab>
 


### PR DESCRIPTION
## Summary
- Follow up on #2922, which merged before the installation doc update.
- Pin Zod to `~4.4.3` in all v4 installation commands (pnpm, npm, Yarn, and Bun), matching the quickstart.
- Allow patch updates while avoiding the reproduced cross-minor `extract()` TypeScript incompatibility.

## Verification
- `git diff --check HEAD^ HEAD` passed.
- Docs-only change; full docs validation not run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Zod to `~4.4.3` in all v4 installation commands to avoid a cross-minor TypeScript incompatibility with `extract()`. This matches the quickstart and allows patch updates while preventing the breaking change.

<sup>Written for commit 90e1bbf93258ab2f7f8737c9ccb3905fb02d057f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

