### PR TITLE
fix(pi): skip screenshot when the active model has no vision

### DIFF
--- a/packages/integrations/pi/extensions/model-capabilities.ts
+++ b/packages/integrations/pi/extensions/model-capabilities.ts
@@ -1,0 +1,25 @@
+/**
+ * Model capability checks, used to keep tool results within what the active
+ * model can actually consume.
+ *
+ * pi's model catalogue declares what each model accepts through `input`.
+ * `screenshot` returns real image content, so a model whose `input` has no
+ * `"image"` entry cannot use it: the capture is dropped or ignored, and the turn
+ * is spent for nothing. pi does not raise an error in that case, so the tool has
+ * to check for itself.
+ *
+ * Unknown shapes return `undefined` and callers should fail open rather than
+ * block a model they cannot classify.
+ */
+
+export type ModelCapabilities = { readonly input?: unknown } | undefined;
+
+/**
+ * `true` when the model accepts image input, `false` when it only accepts text,
+ * `undefined` when the model or its `input` list is unknown.
+ */
+export function modelAcceptsImages(model: ModelCapabilities): boolean | undefined {
+  const input = model?.input;
+  if (!Array.isArray(input)) return undefined;
+  return input.includes("image");
+}

--- a/packages/integrations/pi/extensions/stagehand.ts
+++ b/packages/integrations/pi/extensions/stagehand.ts
@@ -6,7 +6,11 @@
  * importing the contract (descriptions, runtime validators, system prompt)
  * from @browserbasehq/stagehand-integrations/facade rather than restating it.
  */
-import type { AgentToolResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type {
+  AgentToolResult,
+  ExtensionAPI,
+  ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
 import {
@@ -26,6 +30,16 @@ import {
   StagehandFacadeTools,
   stagehandFacadeConfigFromEnv,
 } from "@browserbasehq/stagehand-integrations/facade";
+
+import { modelAcceptsImages } from "./model-capabilities.js";
+
+// `screenshot` returns real image content, which only vision-capable models can
+// consume. Models advertise that through `input` ("text" | "image"). When the
+// active model has no image input, the capture is dropped or ignored and pi
+// reports no error, so the turn is spent for nothing.
+function modelAcceptsImagesForContext(ctx: ExtensionContext | undefined): boolean | undefined {
+  return modelAcceptsImages(ctx?.model);
+}
 
 type FacadeResources = {
   browser: StagehandBrowser;
@@ -149,10 +163,24 @@ export default function stagehandExtension(pi: ExtensionAPI) {
     name: "screenshot",
     label: "Stagehand screenshot",
     description: SCREENSHOT_TOOL_DESCRIPTION,
-    promptSnippet: "screenshot: capture the rendered page as an image",
+    promptSnippet:
+      "screenshot: capture the rendered page as an image (needs a vision-capable model)",
     parameters: screenshotParameters,
     executionMode: "sequential",
-    async execute(_toolCallId, params) {
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const acceptsImages = modelAcceptsImagesForContext(ctx);
+      if (acceptsImages === false) {
+        const active = ctx?.model ? `${ctx.model.provider}/${ctx.model.id}` : "the active model";
+        return {
+          content: [
+            {
+              type: "text",
+              text: `screenshot is unavailable: ${active} does not accept image input, so a capture would be silently discarded. Use the snapshot tool or a run call that returns only the values you need. If visual inspection is required, ask the user to switch to a vision-capable model.`,
+            },
+          ],
+          details: { skipped: "model-has-no-image-input" },
+        } satisfies AgentToolResult<unknown>;
+      }
       const input = ScreenshotInputSchema.parse(params);
       const tools = await facadeTools();
       const shot = await tools.screenshot(input);

--- a/packages/integrations/pi/tests/extension.test.ts
+++ b/packages/integrations/pi/tests/extension.test.ts
@@ -6,7 +6,19 @@ import { describe, expect, it } from "vitest";
 
 import stagehandExtension from "../extensions/stagehand.js";
 
-type Registered = { name: string; description: string; promptGuidelines?: string[] };
+type Registered = {
+  name: string;
+  description: string;
+  promptGuidelines?: string[];
+  promptSnippet?: string;
+  execute?: (
+    toolCallId: string,
+    params: unknown,
+    signal: AbortSignal | undefined,
+    onUpdate: unknown,
+    ctx: unknown,
+  ) => Promise<{ content: Array<{ type: string; text?: string }>; details?: unknown }>;
+};
 
 function registeredTools(): Registered[] {
   const tools: Registered[] = [];
@@ -34,6 +46,25 @@ describe("pi stagehand extension", () => {
   it("forwards the canonical agent instructions as guidelines", () => {
     const run = registeredTools().find((tool) => tool.name === "run");
     expect(run?.promptGuidelines).toEqual([FACADE_AGENT_INSTRUCTIONS]);
+  });
+
+  it("advertises the vision requirement on screenshot", () => {
+    const screenshot = registeredTools().find((tool) => tool.name === "screenshot");
+    expect(screenshot?.promptSnippet).toContain("vision");
+  });
+
+  it("refuses screenshot for a text-only model instead of returning an image", async () => {
+    const screenshot = registeredTools().find((tool) => tool.name === "screenshot");
+    const result = await screenshot?.execute?.("call-1", {}, undefined, undefined, {
+      model: { provider: "opencode-go", id: "qwen3.7-max", input: ["text"] },
+    });
+    expect(result?.details).toEqual({ skipped: "model-has-no-image-input" });
+    expect(result?.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("opencode-go/qwen3.7-max does not accept image input"),
+      },
+    ]);
   });
 
   it("does not launch a browser at registration time", () => {

--- a/packages/integrations/pi/tests/model-capabilities.test.ts
+++ b/packages/integrations/pi/tests/model-capabilities.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { modelAcceptsImages } from "../extensions/model-capabilities.js";
+
+describe("modelAcceptsImages", () => {
+  it("accepts models that declare image input", () => {
+    expect(modelAcceptsImages({ input: ["text", "image"] })).toBe(true);
+    expect(modelAcceptsImages({ input: ["image"] })).toBe(true);
+  });
+
+  it("rejects text-only models", () => {
+    expect(modelAcceptsImages({ input: ["text"] })).toBe(false);
+    expect(modelAcceptsImages({ input: [] })).toBe(false);
+  });
+
+  it("returns undefined when the capability is unknown, so callers fail open", () => {
+    expect(modelAcceptsImages(undefined)).toBeUndefined();
+    expect(modelAcceptsImages({})).toBeUndefined();
+    expect(modelAcceptsImages({ input: "image" })).toBeUndefined();
+    expect(modelAcceptsImages({ input: null })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

`screenshot` now answers with an explicit text result instead of an image when the active model cannot consume images.

## Why

`ScreenshotInputSchema` gives the model a tool that returns real image content, but nothing checks whether the active model accepts images. When it does not — a text-only model such as `Qwen3-235B-A22B-Instruct-2507` or `qwen3.7-max` — pi reports no error and the turn is spent for nothing:

- the tool returns `content: [{ type: "image", ... }]` with `isError: false`,
- the model answers as if it had inspected the page, so the caller cannot tell the capture was discarded.

That is worse than a refusal, because the agent loop continues on a false premise.

## Change

- **`extensions/model-capabilities.ts`** (new): `modelAcceptsImages(model)` reads the model's declared `input` list, the same field `pi --list-models` renders as the `images` column. It returns `true`, `false`, or `undefined` when the capability is unknown.
- **`screenshot`** checks the active model through the tool's `ExtensionContext` before capturing. On a text-only model it returns a text result naming the model — `screenshot is unavailable: opencode-go/qwen3.7-max does not accept image input...` — and points at `snapshot`/`run` as the alternatives, without launching the browser.
- The unknown case fails open: a model whose capabilities cannot be read is never blocked.
- The tool snippet now advertises the requirement: `screenshot: capture the rendered page as an image (needs a vision-capable model)`.

## Verification

- `vitest run` in `packages/integrations/pi`: 8 tests pass, including `modelAcceptsImages` cases and an extension test that calls the registered tool's `execute` with a text-only model and asserts the refusal.
- `tsc --noEmit`, `oxlint`, and `oxfmt --check` are clean for the touched files.
- Manual, end to end:
  - text-only model (`opencode-go/qwen3.7-max`): the tool returns the refusal text, the model reports it and stops, no browser is launched;
  - vision model: the image arrives and is described correctly ("A minimal white page with the heading \"Example Domain,\" ...").

I ran the TypeScript checks scoped to `packages/integrations/pi` rather than `just check` / `just test`, because `just`, Go 1.26, and `uv` are not installed in my environment. No changeset: `packages/integrations/pi` is private and this is not a public SDK, extension, or protocol change.

## Note on ordering

This is independent of the `snapshot` compaction change. Both touch the import block of the same file, so whichever lands second needs a trivial rebase there.

---

Developed and verified with an AI coding agent in a local checkout; the test results above come from that checkout.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `screenshot` tool refuse to run when the active model can't consume images. Previously it returned a real image even for text-only models, so those models answered as if they'd inspected the page and the capture was silently discarded; now it returns a text result naming the model and pointing at `snapshot`/`run` as alternatives, without launching the browser.

- Reads the model's declared `input` list; unknown capability shapes fail open and never block a model.
- The tool's prompt snippet now advertises the vision requirement.

<sup>Written for commit d894d3e6537974447338e0cbe9d71b5f34d2526d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

