### PR TITLE
fix(cli): hide Windows daemon console window

### DIFF
--- a/packages/cli/src/lib/driver/daemon/client.ts
+++ b/packages/cli/src/lib/driver/daemon/client.ts
@@ -270,6 +270,7 @@ function spawnDaemon(session: string, target: ConnectionTarget): void {
       detached: true,
       env: process.env,
       stdio: "ignore",
+      windowsHide: true,
     },
   );
   child.unref();

--- a/packages/cli/tests/daemon-spawn.test.ts
+++ b/packages/cli/tests/daemon-spawn.test.ts
@@ -1,0 +1,85 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { createConnectionMock, spawnMock } = vi.hoisted(() => {
+  let connectionAttempt = 0;
+
+  return {
+    createConnectionMock: vi.fn(() => {
+      const socket = Object.assign(new EventEmitter(), { destroy: vi.fn() });
+      const attempt = connectionAttempt++;
+      queueMicrotask(() => {
+        if (attempt < 2) {
+          const error = Object.assign(new Error("socket missing"), {
+            code: "ENOENT",
+          });
+          socket.emit("error", error);
+          return;
+        }
+        socket.emit("connect");
+      });
+      return socket;
+    }),
+    spawnMock: vi.fn(() => ({ unref: vi.fn() })),
+  };
+});
+
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+vi.mock("node:net", () => ({
+  createConnection: createConnectionMock,
+  default: { createConnection: createConnectionMock },
+}));
+
+import { ensureDriverDaemon } from "../src/lib/driver/daemon/client.js";
+
+const cleanupPaths: string[] = [];
+const originalDaemonDir = process.env.BROWSE_DAEMON_DIR;
+
+afterEach(async () => {
+  if (originalDaemonDir === undefined) {
+    delete process.env.BROWSE_DAEMON_DIR;
+  } else {
+    process.env.BROWSE_DAEMON_DIR = originalDaemonDir;
+  }
+  vi.clearAllMocks();
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (path) await rm(path, { recursive: true, force: true });
+  }
+});
+
+describe("driver daemon startup", () => {
+  it("hides the detached daemon process window on Windows", async () => {
+    const daemonDir = await mkdtemp(join(tmpdir(), "browse-daemon-spawn-"));
+    cleanupPaths.push(daemonDir);
+    process.env.BROWSE_DAEMON_DIR = daemonDir;
+
+    await ensureDriverDaemon({
+      session: "default",
+      target: { kind: "auto-connect" },
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      [
+        expect.any(String),
+        "daemon",
+        "--session",
+        "default",
+        "--target",
+        JSON.stringify({ kind: "auto-connect" }),
+      ],
+      expect.objectContaining({
+        detached: true,
+        env: process.env,
+        stdio: "ignore",
+        windowsHide: true,
+      }),
+    );
+    expect(createConnectionMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
# why

On Windows, the detached Browse driver daemon starts without `windowsHide`, so headless sessions briefly flash a console window and can steal focus from the user's terminal or editor. This is the behavior reported in #2918.

# what changed

- Pass `windowsHide: true` when spawning the detached driver daemon.
- Add a regression test that exercises daemon startup and asserts the complete spawn contract.
- No changeset is included because the repository changeset config ignores the `browse` package.

# test plan

- `pnpm --filter browse test -- daemon-spawn.test.ts`
- `pnpm exec prettier --check src/lib/driver/daemon/client.ts tests/daemon-spawn.test.ts`
- `pnpm exec eslint src/lib/driver/daemon/client.ts tests/daemon-spawn.test.ts`
- `pnpm check`
- `git diff --check`

The focused test, formatting, ESLint, and TypeScript checks pass. The full CLI suite also exposed four failures in unchanged telemetry tests under this Windows environment; they return `3221226505` instead of the expected exit code and are not related to the two changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows console flash and focus stealing from the detached Browse driver daemon (#2918) by passing `windowsHide: true` when spawning it. Also adds a regression test that asserts the full daemon spawn contract.

No changeset is included because the repository changeset config ignores the `browse` package.

<sup>Written for commit 9a29b5ba538fcb010283d247de3436d5d80949f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

